### PR TITLE
fix: handle missing child chain tx receipt

### DIFF
--- a/packages/retryable-monitor/index.ts
+++ b/packages/retryable-monitor/index.ts
@@ -435,6 +435,19 @@ const processChildChain = async (
                   retryableMessage.retryableCreationId
                 )
 
+              if (!childChainTxReceipt) {
+                // if child-chain tx is very recent, the tx receipt might not be found yet
+                // if not handled, this will result in `undefined` error while trying to extract retryable details
+                const resultMessage = `${msgIndex + 1}. ${
+                  ParentToChildMessageStatus[status]
+                }:\nChildChainTxHash: ${
+                  CHILD_CHAIN_TX_PREFIX + retryableTicketId
+                } (Receipt not found yet)`
+                logResult(childChain.name, resultMessage)
+
+                return false
+              }
+
               const parentChainTicketReport = getParentChainTicketReport(
                 arbParentTxReceipt,
                 retryableMessage

--- a/packages/retryable-monitor/index.ts
+++ b/packages/retryable-monitor/index.ts
@@ -445,7 +445,7 @@ const processChildChain = async (
                 } (Receipt not found yet)`
                 logResult(childChain.name, resultMessage)
 
-                return false
+                continue
               }
 
               const parentChainTicketReport = getParentChainTicketReport(


### PR DESCRIPTION
Link to error and logs : 
1. https://github.com/OffchainLabs/arbitrum-token-bridge/actions/runs/10026776587/job/27711527867#step:10:1854
2. https://offchainlabs.slack.com/archives/C076QM36VHC/p1721549396584599

When child-chain tx receipt is not yet generated because transaction is too recent, log the result and early return.