### PR TITLE
feat: batch-poster-balance check fallback

### DIFF
--- a/packages/batch-poster-monitor/chains.ts
+++ b/packages/batch-poster-monitor/chains.ts
@@ -14,7 +14,7 @@ import {
 export const DEFAULT_TIMESPAN_SECONDS = 60 * 60 * 12 // 12 hours
 export const DEFAULT_BATCH_POSTING_DELAY_SECONDS = 60 * 60 * 4 // 4 hours
 export const LOW_ETH_BALANCE_THRESHOLD_ETHEREUM = 1
-export const LOW_ETH_BALANCE_THRESHOLD_ARBITRUM = 0.2
+export const LOW_ETH_BALANCE_THRESHOLD_ARBITRUM = 0.1
 
 export const supportedParentChains = [
   mainnet,

--- a/packages/batch-poster-monitor/index.ts
+++ b/packages/batch-poster-monitor/index.ts
@@ -210,11 +210,8 @@ const getBatchPosterLowBalanceAlertMessage = async (
       )
     } catch {
       // batchPoster not found by any means
+      return `Batch poster information not found`
     }
-  }
-
-  if (!batchPoster) {
-    return `Batch poster information not found`
   }
 
   const balance = await parentChainClient.getBalance({

--- a/packages/batch-poster-monitor/index.ts
+++ b/packages/batch-poster-monitor/index.ts
@@ -193,14 +193,21 @@ const getBatchPosterLowBalanceAlertMessage = async (
 
   // try fetching batch poster address from orbit-sdk
   try {
-    //@ts-ignore - PublicClient that we pass vs PublicClient that orbit-sdk expects is not matching
-    const { batchPosters } = await getBatchPosters(parentChainClient, {
-      rollup: childChainInformation.ethBridge.rollup as `0x${string}`,
-      sequencerInbox: childChainInformation.ethBridge
-        .sequencerInbox as `0x${string}`,
-    })
+    const { batchPosters, isAccurate } = await getBatchPosters(
+      //@ts-ignore - PublicClient that we pass vs PublicClient that orbit-sdk expects is not matching
+      parentChainClient,
+      {
+        rollup: childChainInformation.ethBridge.rollup as `0x${string}`,
+        sequencerInbox: childChainInformation.ethBridge
+          .sequencerInbox as `0x${string}`,
+      }
+    )
 
-    batchPoster = batchPosters[0] // get the first batch poster
+    if (isAccurate) {
+      batchPoster = batchPosters[0] // get the first batch poster
+    } else {
+      throw Error('Batch poster list is not accurate') // get the batch poster from the event logs in catch block
+    }
   } catch {
     // else try fetching the batch poster from the event logs
     try {
@@ -210,7 +217,7 @@ const getBatchPosterLowBalanceAlertMessage = async (
       )
     } catch {
       // batchPoster not found by any means
-      return `Batch poster information not found`
+      return 'Batch poster information not found'
     }
   }
 

--- a/packages/batch-poster-monitor/index.ts
+++ b/packages/batch-poster-monitor/index.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs'
 import * as path from 'path'
 import yargs from 'yargs'
 import {
+  Log,
   PublicClient,
   createPublicClient,
   defineChain,
@@ -161,23 +162,60 @@ const showAlert = (childChainInformation: ChainInfo, reasons: string[]) => {
   )
 }
 
+type EventLogs = Log<
+  bigint,
+  number,
+  false,
+  AbiEvent,
+  undefined,
+  [AbiEvent],
+  string
+>[]
+
+const getBatchPosterFromEventLogs = async (
+  eventLogs: EventLogs,
+  parentChainClient: PublicClient
+) => {
+  // get the batch-poster for the first event log
+  const batchPostingTransactionHash = eventLogs[0].transactionHash
+  const tx = await parentChainClient.getTransaction({
+    hash: batchPostingTransactionHash,
+  })
+  return tx.from
+}
+
 const getBatchPosterLowBalanceAlertMessage = async (
   parentChainClient: PublicClient,
-  childChainInformation: ChainInfo
+  childChainInformation: ChainInfo,
+  sequencerInboxLogs: EventLogs
 ) => {
-  if (childChainInformation.parentChainId === 1) return null // skip balance check for Ethereum batch poster till it's fixed in orbit-sdk (fetches logs from genesis)
+  let batchPoster: `0x${string}` | null = null
 
-  //@ts-ignore - PublicClient that we pass vs PublicClient that orbit-sdk expects is not matching
-  const { batchPosters } = await getBatchPosters(parentChainClient, {
-    rollup: childChainInformation.ethBridge.rollup as `0x${string}`,
-    sequencerInbox: childChainInformation.ethBridge
-      .sequencerInbox as `0x${string}`,
-  })
-  if (!batchPosters || batchPosters.length === 0) {
-    return `Batch poster information not found`
+  // try fetching batch poster address from orbit-sdk
+  try {
+    //@ts-ignore - PublicClient that we pass vs PublicClient that orbit-sdk expects is not matching
+    const { batchPosters } = await getBatchPosters(parentChainClient, {
+      rollup: childChainInformation.ethBridge.rollup as `0x${string}`,
+      sequencerInbox: childChainInformation.ethBridge
+        .sequencerInbox as `0x${string}`,
+    })
+
+    batchPoster = batchPosters[0] // get the first batch poster
+  } catch {
+    // else try fetching the batch poster from the event logs
+    try {
+      batchPoster = await getBatchPosterFromEventLogs(
+        sequencerInboxLogs,
+        parentChainClient
+      )
+    } catch {
+      // batchPoster not found by any means
+    }
   }
 
-  const batchPoster = batchPosters[0]
+  if (!batchPoster) {
+    return `Batch poster information not found`
+  }
 
   const balance = await parentChainClient.getBalance({
     address: batchPoster,
@@ -233,16 +271,6 @@ const monitorBatchPoster = async (childChainInformation: ChainInfo) => {
     transport: http(childChainInformation.orbitRpcUrl),
   })
 
-  // First, a basic check to get batch poster balance
-  const batchPosterLowBalanceMessage =
-    await getBatchPosterLowBalanceAlertMessage(
-      parentChainClient,
-      childChainInformation
-    )
-  if (batchPosterLowBalanceMessage) {
-    alertsForChildChain.push(batchPosterLowBalanceMessage)
-  }
-
   // Getting sequencer inbox logs
   const latestBlockNumber = await parentChainClient.getBlockNumber()
 
@@ -277,6 +305,17 @@ const monitorBatchPoster = async (childChainInformation: ChainInfo) => {
 
   // Flatten the array of arrays to get final array of logs
   const sequencerInboxLogs = sequencerInboxLogsArray.flat()
+
+  // First, a basic check to get batch poster balance
+  const batchPosterLowBalanceMessage =
+    await getBatchPosterLowBalanceAlertMessage(
+      parentChainClient,
+      childChainInformation,
+      sequencerInboxLogs
+    )
+  if (batchPosterLowBalanceMessage) {
+    alertsForChildChain.push(batchPosterLowBalanceMessage)
+  }
 
   // Get the last block of the chain
   const latestChildChainBlockNumber = await childChainClient.getBlockNumber()

--- a/packages/batch-poster-monitor/index.ts
+++ b/packages/batch-poster-monitor/index.ts
@@ -165,6 +165,8 @@ const getBatchPosterLowBalanceAlertMessage = async (
   parentChainClient: PublicClient,
   childChainInformation: ChainInfo
 ) => {
+  if (childChainInformation.parentChainId === 1) return null // skip balance check for Ethereum batch poster till it's fixed in orbit-sdk (fetches logs from genesis)
+
   //@ts-ignore - PublicClient that we pass vs PublicClient that orbit-sdk expects is not matching
   const { batchPosters } = await getBatchPosters(parentChainClient, {
     rollup: childChainInformation.ethBridge.rollup as `0x${string}`,


### PR DESCRIPTION
Fetches batch poster address from event logs in addition to being fetched from `orbit-sdk` (currently for core chains `orbit-sdk` is fetching logs from genesis so throws error and exits the script prematurely)