### PR TITLE
feat: dynamic timebounds for batch posting

### DIFF
--- a/packages/batch-poster-monitor/chains.ts
+++ b/packages/batch-poster-monitor/chains.ts
@@ -13,8 +13,8 @@ import {
 
 // Defaults
 export const MAX_TIMEBOUNDS_SECONDS = 60 * 60 * 24 // 24 hours : we don't care about txs older than 24 hours
-export const BATCH_POSTING_TIMEBOUNDS_FALLBACK = 60 * 60 * 4 // 4 hours : fallback in case we can't derive the on-chain timebounds for batch posting
-export const BATCH_POSTING_TIMEBOUNDS_BUFFER = 60 * 60 * 12 // 12 hours: add buffer to the time bounds to account for any delays
+export const BATCH_POSTING_TIMEBOUNDS_FALLBACK = 60 * 60 * 12 // fallback in case we can't derive the on-chain timebounds for batch posting
+export const BATCH_POSTING_TIMEBOUNDS_BUFFER = 60 * 60 * 9 // reduce buffer (secs) from the time bounds for proactive alerting
 export const LOW_ETH_BALANCE_THRESHOLD_ETHEREUM = 1
 export const LOW_ETH_BALANCE_THRESHOLD_ARBITRUM = 0.1
 

--- a/packages/batch-poster-monitor/chains.ts
+++ b/packages/batch-poster-monitor/chains.ts
@@ -1,3 +1,4 @@
+import { ChildNetwork } from 'utils'
 import { Chain } from 'viem'
 import {
   mainnet,
@@ -11,8 +12,9 @@ import {
 } from 'viem/chains'
 
 // Defaults
-export const DEFAULT_TIMESPAN_SECONDS = 60 * 60 * 24 // 24 hours : we don't care about txs older than 24 hours
-export const DEFAULT_BATCH_POSTING_DELAY_SECONDS = 60 * 60 * 4 // 4 hours
+export const MAX_TIMEBOUNDS_SECONDS = 60 * 60 * 24 // 24 hours : we don't care about txs older than 24 hours
+export const BATCH_POSTING_TIMEBOUNDS_FALLBACK = 60 * 60 * 4 // 4 hours : fallback in case we can't derive the on-chain timebounds for batch posting
+export const BATCH_POSTING_TIMEBOUNDS_BUFFER = 60 * 60 * 12 // 12 hours: add buffer to the time bounds to account for any delays
 export const LOW_ETH_BALANCE_THRESHOLD_ETHEREUM = 1
 export const LOW_ETH_BALANCE_THRESHOLD_ARBITRUM = 0.1
 
@@ -33,22 +35,35 @@ export const getChainFromId = (chainId: number): Chain => {
   return chain[0] ?? null
 }
 
-export const getDefaultBlockRange = (chain: Chain): bigint => {
+export const getMaxBlockRange = (chain: Chain): bigint => {
   switch (chain) {
     case mainnet:
     case sepolia:
     case holesky:
-      return BigInt(DEFAULT_TIMESPAN_SECONDS / 12)
+      return BigInt(MAX_TIMEBOUNDS_SECONDS / 12)
 
     case base:
     case baseSepolia:
-      return BigInt(DEFAULT_TIMESPAN_SECONDS / 2)
+      return BigInt(MAX_TIMEBOUNDS_SECONDS / 2)
 
     case arbitrum:
     case arbitrumNova:
     case arbitrumSepolia:
-      return BigInt(DEFAULT_TIMESPAN_SECONDS * 4)
+      return BigInt(MAX_TIMEBOUNDS_SECONDS * 4)
   }
 
   return 0n
+}
+
+// this is different from simple `getParentChainBlockTime` in retryable-tracker because we need to fallback to Ethereum values no matter what the chain
+export const getParentChainBlockTimeForBatchPosting = (
+  childChain: ChildNetwork
+) => {
+  const parentChainId = childChain.parentChainId
+
+  // for Base / Base Sepolia
+  if (parentChainId === 8453 || parentChainId === 84532) return 2
+
+  // for arbitrum networks, return the block-time corresponding to Ethereum
+  return 12
 }

--- a/packages/batch-poster-monitor/config.json
+++ b/packages/batch-poster-monitor/config.json
@@ -1,86 +1,56 @@
 {
   "childChains": [
     {
-      "chainId": 42161,
-      "name": "Arbitrum One",
-      "parentChainId": 1,
-      "tokenBridge": {
-        "parentGatewayRouter": "0x72Ce9c846789fdB6fC1f34aC4AD25Dd9ef7031ef",
-        "childGatewayRouter": "0x5288c571Fd7aD117beA99bF60FE0846C4E84F933",
-        "parentErc20Gateway": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC",
-        "childErc20Gateway": "0x09e9222E96E7B4AE2a407B98d48e330053351EEe",
-        "parentCustomGateway": "0xcEe284F754E854890e311e3280b767F80797180d",
-        "childCustomGateway": "0x096760F208390250649E3e8763348E783AEF5562",
-        "parentWethGateway": "0xd92023E9d9911199a6711321D1277285e6d4e2db",
-        "childWethGateway": "0x6c411aD3E74De3E7Bd422b94A27770f5B86C623B",
-        "childWeth": "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
-        "parentWeth": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
-        "parentProxyAdmin": "0x9aD46fac0Cf7f790E5be05A0F15223935A0c0aDa",
-        "childProxyAdmin": "0xd570aCE65C43af47101fC6250FD6fC63D1c22a86",
-        "parentMultiCall": "0x5ba1e12693dc8f9c48aad8770482f4739beed696",
-        "childMultiCall": "0x842eC2c7D803033Edf55E478F461FC547Bc54EB2"
-      },
+      "chainId": 37714555429,
+      "confirmPeriodBlocks": 150,
       "ethBridge": {
-        "bridge": "0x8315177aB297bA92A06054cE80a67Ed4DBd7ed3a",
-        "inbox": "0x4Dbd4fc535Ac27206064B68FfCf827b0A60BAB3f",
-        "sequencerInbox": "0x1c479675ad559DC151F6Ec7ed3FbF8ceE79582B6",
-        "outbox": "0x0B9857ae2D4A3DBe74ffE1d7DF045bb7F96E4840",
-        "rollup": "0x5eF0D09d1E6204141B4d37530808eD19f60FBa35",
-        "classicOutboxes": {
-          "0x667e23ABd27E623c11d4CC00ca3EC4d0bD63337a": 0,
-          "0x760723CD2e632826c38Fef8CD438A4CC7E7E1A40": 30
+        "bridge": "0x6c7FAC4edC72E86B3388B48979eF37Ecca5027e6",
+        "inbox": "0x6396825803B720bc6A43c63caa1DcD7B31EB4dd0",
+        "outbox": "0xc7491a559b416540427f9f112C5c98b1412c5d51",
+        "rollup": "0xeedE9367Df91913ab149e828BDd6bE336df2c892",
+        "sequencerInbox": "0x529a2061A1973be80D315770bA9469F3Da40D938"
+      },
+      "nativeToken": "0x4e6f41acbfa8eb4a3b25e151834d9a14b49b69d2",
+      "explorerUrl": "https://testnet-explorer-v2.xai-chain.net/",
+      "rpcUrl": "https://testnet-v2.xai-chain.net/rpc",
+      "name": "Xai Testnet",
+      "slug": "xai-testnet",
+      "parentChainId": 421614,
+      "retryableLifetimeSeconds": 604800,
+      "isCustom": true,
+      "tokenBridge": {
+        "parentCustomGateway": "0x04e14E04949D49ae9c551ca8Cc3192310Ce65D88",
+        "parentErc20Gateway": "0xCcB451C4Df22addCFe1447c58bC6b2f264Bb1256",
+        "parentGatewayRouter": "0x185b868DBBF41554465fcb99C6FAb9383E15f47A",
+        "parentMultiCall": "0xA115146782b7143fAdB3065D86eACB54c169d092",
+        "parentProxyAdmin": "0x022c515aEAb29aaFf82e86A10950cE14eA89C9c5",
+        "parentWeth": "0x0000000000000000000000000000000000000000",
+        "parentWethGateway": "0x0000000000000000000000000000000000000000",
+        "childCustomGateway": "0xea1ce1CC75C948488515A3058E10aa82da40cE8F",
+        "childErc20Gateway": "0xD840761a09609394FaFA3404bEEAb312059AC558",
+        "childGatewayRouter": "0x3B8ba769a43f34cdD67a20aF60d08D54C9C8f1AD",
+        "childMultiCall": "0x5CBd60Ae5Af80A42FA8b0F20ADF95A8879844984",
+        "childProxyAdmin": "0x7C1BA251d812fb34aF5C2566040C3C30585aFed9",
+        "childWeth": "0x0000000000000000000000000000000000000000",
+        "childWethGateway": "0x0000000000000000000000000000000000000000"
+      },
+      "bridgeUiConfig": {
+        "color": "#F30019",
+        "network": {
+          "name": "Xai Testnet",
+          "logo": "/images/XaiLogo.svg",
+          "description": "The testnet for Xai’s gaming chain."
+        },
+        "nativeTokenData": {
+          "name": "Xai",
+          "symbol": "sXAI",
+          "decimals": 18,
+          "logoUrl": "/images/XaiLogo.svg"
         }
       },
-      "teleporter": {
-        "l1Teleporter": "0xCBd9c6e310D6AaDeF9F025f716284162F0158992",
-        "l2ForwarderFactory": "0x791d2AbC6c3A459E13B9AdF54Fb5e97B7Af38f87"
-      },
-      "confirmPeriodBlocks": 45818,
-      "isCustom": false,
-      "rpcURL": "https://arbitrum-mainnet.infura.io/v3/76e00fd3e22e410e9bc0885920c9e00b",
-      "explorerUrl": "https://arbiscan.io/",
-      "orbitRpcUrl": "https://arbitrum-mainnet.infura.io/v3/76e00fd3e22e410e9bc0885920c9e00b",
-      "parentRpcUrl": "https://eth.llamarpc.com",
-      "parentExplorerUrl": "https://etherscan.io/"
-    },
-    {
-      "chainId": 42170,
-      "confirmPeriodBlocks": 45818,
-      "ethBridge": {
-        "bridge": "0xC1Ebd02f738644983b6C4B2d440b8e77DdE276Bd",
-        "inbox": "0xc4448b71118c9071Bcb9734A0EAc55D18A153949",
-        "outbox": "0xD4B80C3D7240325D18E645B49e6535A3Bf95cc58",
-        "rollup": "0xFb209827c58283535b744575e11953DCC4bEAD88",
-        "sequencerInbox": "0x211E1c4c7f1bF5351Ac850Ed10FD68CFfCF6c21b"
-      },
-      "isCustom": false,
-      "name": "Arbitrum Nova",
-      "parentChainId": 1,
-      "tokenBridge": {
-        "parentCustomGateway": "0x23122da8C581AA7E0d07A36Ff1f16F799650232f",
-        "parentErc20Gateway": "0xB2535b988dcE19f9D71dfB22dB6da744aCac21bf",
-        "parentGatewayRouter": "0xC840838Bc438d73C16c2f8b22D2Ce3669963cD48",
-        "parentMultiCall": "0x8896D23AfEA159a5e9b72C9Eb3DC4E2684A38EA3",
-        "parentProxyAdmin": "0xa8f7DdEd54a726eB873E98bFF2C95ABF2d03e560",
-        "parentWeth": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
-        "parentWethGateway": "0xE4E2121b479017955Be0b175305B35f312330BaE",
-        "childCustomGateway": "0xbf544970E6BD77b21C6492C281AB60d0770451F4",
-        "childErc20Gateway": "0xcF9bAb7e53DDe48A6DC4f286CB14e05298799257",
-        "childGatewayRouter": "0x21903d3F8176b1a0c17E953Cd896610Be9fFDFa8",
-        "childMultiCall": "0x5e1eE626420A354BbC9a95FeA1BAd4492e3bcB86",
-        "childProxyAdmin": "0xada790b026097BfB36a5ed696859b97a96CEd92C",
-        "childWeth": "0x722E8BdD2ce80A4422E880164f2079488e115365",
-        "childWethGateway": "0x7626841cB6113412F9c88D3ADC720C9FAC88D9eD"
-      },
-      "teleporter": {
-        "l1Teleporter": "0xCBd9c6e310D6AaDeF9F025f716284162F0158992",
-        "l2ForwarderFactory": "0x791d2AbC6c3A459E13B9AdF54Fb5e97B7Af38f87"
-      },
-      "rpcURL": "https://nova.arbitrum.io/vip/xkxvagy7gt4kiuyb7942rso2kw8xbsmb",
-      "explorerUrl": "https://nova.arbiscan.io/",
-      "orbitRpcUrl": "https://nova.arbitrum.io/vip/xkxvagy7gt4kiuyb7942rso2kw8xbsmb",
-      "parentRpcUrl": "https://eth.llamarpc.com",
-      "parentExplorerUrl": "https://etherscan.io/"
+      "orbitRpcUrl": "https://testnet-v2.xai-chain.net/rpc",
+      "parentRpcUrl": "https://sepolia-rollup.arbitrum.io/rpc",
+      "parentExplorerUrl": "https://sepolia.arbiscan.io/"
     }
   ]
 }

--- a/packages/batch-poster-monitor/config.json
+++ b/packages/batch-poster-monitor/config.json
@@ -1,56 +1,86 @@
 {
   "childChains": [
     {
-      "chainId": 37714555429,
-      "confirmPeriodBlocks": 150,
-      "ethBridge": {
-        "bridge": "0x6c7FAC4edC72E86B3388B48979eF37Ecca5027e6",
-        "inbox": "0x6396825803B720bc6A43c63caa1DcD7B31EB4dd0",
-        "outbox": "0xc7491a559b416540427f9f112C5c98b1412c5d51",
-        "rollup": "0xeedE9367Df91913ab149e828BDd6bE336df2c892",
-        "sequencerInbox": "0x529a2061A1973be80D315770bA9469F3Da40D938"
-      },
-      "nativeToken": "0x4e6f41acbfa8eb4a3b25e151834d9a14b49b69d2",
-      "explorerUrl": "https://testnet-explorer-v2.xai-chain.net/",
-      "rpcUrl": "https://testnet-v2.xai-chain.net/rpc",
-      "name": "Xai Testnet",
-      "slug": "xai-testnet",
-      "parentChainId": 421614,
-      "retryableLifetimeSeconds": 604800,
-      "isCustom": true,
+      "chainId": 42161,
+      "name": "Arbitrum One",
+      "parentChainId": 1,
       "tokenBridge": {
-        "parentCustomGateway": "0x04e14E04949D49ae9c551ca8Cc3192310Ce65D88",
-        "parentErc20Gateway": "0xCcB451C4Df22addCFe1447c58bC6b2f264Bb1256",
-        "parentGatewayRouter": "0x185b868DBBF41554465fcb99C6FAb9383E15f47A",
-        "parentMultiCall": "0xA115146782b7143fAdB3065D86eACB54c169d092",
-        "parentProxyAdmin": "0x022c515aEAb29aaFf82e86A10950cE14eA89C9c5",
-        "parentWeth": "0x0000000000000000000000000000000000000000",
-        "parentWethGateway": "0x0000000000000000000000000000000000000000",
-        "childCustomGateway": "0xea1ce1CC75C948488515A3058E10aa82da40cE8F",
-        "childErc20Gateway": "0xD840761a09609394FaFA3404bEEAb312059AC558",
-        "childGatewayRouter": "0x3B8ba769a43f34cdD67a20aF60d08D54C9C8f1AD",
-        "childMultiCall": "0x5CBd60Ae5Af80A42FA8b0F20ADF95A8879844984",
-        "childProxyAdmin": "0x7C1BA251d812fb34aF5C2566040C3C30585aFed9",
-        "childWeth": "0x0000000000000000000000000000000000000000",
-        "childWethGateway": "0x0000000000000000000000000000000000000000"
+        "parentGatewayRouter": "0x72Ce9c846789fdB6fC1f34aC4AD25Dd9ef7031ef",
+        "childGatewayRouter": "0x5288c571Fd7aD117beA99bF60FE0846C4E84F933",
+        "parentErc20Gateway": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC",
+        "childErc20Gateway": "0x09e9222E96E7B4AE2a407B98d48e330053351EEe",
+        "parentCustomGateway": "0xcEe284F754E854890e311e3280b767F80797180d",
+        "childCustomGateway": "0x096760F208390250649E3e8763348E783AEF5562",
+        "parentWethGateway": "0xd92023E9d9911199a6711321D1277285e6d4e2db",
+        "childWethGateway": "0x6c411aD3E74De3E7Bd422b94A27770f5B86C623B",
+        "childWeth": "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
+        "parentWeth": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "parentProxyAdmin": "0x9aD46fac0Cf7f790E5be05A0F15223935A0c0aDa",
+        "childProxyAdmin": "0xd570aCE65C43af47101fC6250FD6fC63D1c22a86",
+        "parentMultiCall": "0x5ba1e12693dc8f9c48aad8770482f4739beed696",
+        "childMultiCall": "0x842eC2c7D803033Edf55E478F461FC547Bc54EB2"
       },
-      "bridgeUiConfig": {
-        "color": "#F30019",
-        "network": {
-          "name": "Xai Testnet",
-          "logo": "/images/XaiLogo.svg",
-          "description": "The testnet for Xai’s gaming chain."
-        },
-        "nativeTokenData": {
-          "name": "Xai",
-          "symbol": "sXAI",
-          "decimals": 18,
-          "logoUrl": "/images/XaiLogo.svg"
+      "ethBridge": {
+        "bridge": "0x8315177aB297bA92A06054cE80a67Ed4DBd7ed3a",
+        "inbox": "0x4Dbd4fc535Ac27206064B68FfCf827b0A60BAB3f",
+        "sequencerInbox": "0x1c479675ad559DC151F6Ec7ed3FbF8ceE79582B6",
+        "outbox": "0x0B9857ae2D4A3DBe74ffE1d7DF045bb7F96E4840",
+        "rollup": "0x5eF0D09d1E6204141B4d37530808eD19f60FBa35",
+        "classicOutboxes": {
+          "0x667e23ABd27E623c11d4CC00ca3EC4d0bD63337a": 0,
+          "0x760723CD2e632826c38Fef8CD438A4CC7E7E1A40": 30
         }
       },
-      "orbitRpcUrl": "https://testnet-v2.xai-chain.net/rpc",
-      "parentRpcUrl": "https://sepolia-rollup.arbitrum.io/rpc",
-      "parentExplorerUrl": "https://sepolia.arbiscan.io/"
+      "teleporter": {
+        "l1Teleporter": "0xCBd9c6e310D6AaDeF9F025f716284162F0158992",
+        "l2ForwarderFactory": "0x791d2AbC6c3A459E13B9AdF54Fb5e97B7Af38f87"
+      },
+      "confirmPeriodBlocks": 45818,
+      "isCustom": false,
+      "rpcURL": "https://arbitrum-mainnet.infura.io/v3/76e00fd3e22e410e9bc0885920c9e00b",
+      "explorerUrl": "https://arbiscan.io/",
+      "orbitRpcUrl": "https://arbitrum-mainnet.infura.io/v3/76e00fd3e22e410e9bc0885920c9e00b",
+      "parentRpcUrl": "https://eth.llamarpc.com",
+      "parentExplorerUrl": "https://etherscan.io/"
+    },
+    {
+      "chainId": 42170,
+      "confirmPeriodBlocks": 45818,
+      "ethBridge": {
+        "bridge": "0xC1Ebd02f738644983b6C4B2d440b8e77DdE276Bd",
+        "inbox": "0xc4448b71118c9071Bcb9734A0EAc55D18A153949",
+        "outbox": "0xD4B80C3D7240325D18E645B49e6535A3Bf95cc58",
+        "rollup": "0xFb209827c58283535b744575e11953DCC4bEAD88",
+        "sequencerInbox": "0x211E1c4c7f1bF5351Ac850Ed10FD68CFfCF6c21b"
+      },
+      "isCustom": false,
+      "name": "Arbitrum Nova",
+      "parentChainId": 1,
+      "tokenBridge": {
+        "parentCustomGateway": "0x23122da8C581AA7E0d07A36Ff1f16F799650232f",
+        "parentErc20Gateway": "0xB2535b988dcE19f9D71dfB22dB6da744aCac21bf",
+        "parentGatewayRouter": "0xC840838Bc438d73C16c2f8b22D2Ce3669963cD48",
+        "parentMultiCall": "0x8896D23AfEA159a5e9b72C9Eb3DC4E2684A38EA3",
+        "parentProxyAdmin": "0xa8f7DdEd54a726eB873E98bFF2C95ABF2d03e560",
+        "parentWeth": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+        "parentWethGateway": "0xE4E2121b479017955Be0b175305B35f312330BaE",
+        "childCustomGateway": "0xbf544970E6BD77b21C6492C281AB60d0770451F4",
+        "childErc20Gateway": "0xcF9bAb7e53DDe48A6DC4f286CB14e05298799257",
+        "childGatewayRouter": "0x21903d3F8176b1a0c17E953Cd896610Be9fFDFa8",
+        "childMultiCall": "0x5e1eE626420A354BbC9a95FeA1BAd4492e3bcB86",
+        "childProxyAdmin": "0xada790b026097BfB36a5ed696859b97a96CEd92C",
+        "childWeth": "0x722E8BdD2ce80A4422E880164f2079488e115365",
+        "childWethGateway": "0x7626841cB6113412F9c88D3ADC720C9FAC88D9eD"
+      },
+      "teleporter": {
+        "l1Teleporter": "0xCBd9c6e310D6AaDeF9F025f716284162F0158992",
+        "l2ForwarderFactory": "0x791d2AbC6c3A459E13B9AdF54Fb5e97B7Af38f87"
+      },
+      "rpcURL": "https://nova.arbitrum.io/vip/xkxvagy7gt4kiuyb7942rso2kw8xbsmb",
+      "explorerUrl": "https://nova.arbiscan.io/",
+      "orbitRpcUrl": "https://nova.arbitrum.io/vip/xkxvagy7gt4kiuyb7942rso2kw8xbsmb",
+      "parentRpcUrl": "https://eth.llamarpc.com",
+      "parentExplorerUrl": "https://etherscan.io/"
     }
   ]
 }

--- a/packages/batch-poster-monitor/index.ts
+++ b/packages/batch-poster-monitor/index.ts
@@ -462,8 +462,7 @@ const monitorBatchPoster = async (childChainInformation: ChainInfo) => {
   })
 
   // Get batch poster backlog
-  const batchPosterBacklog =
-    latestChildChainBlockNumber - lastBlockReported - 1n
+  const batchPosterBacklog = latestChildChainBlockNumber - lastBlockReported
 
   // If there's backlog and last batch posted was 4 hours ago, send alert
   if (

--- a/packages/batch-poster-monitor/index.ts
+++ b/packages/batch-poster-monitor/index.ts
@@ -16,11 +16,11 @@ import {
   getChainFromId,
   LOW_ETH_BALANCE_THRESHOLD_ETHEREUM,
   LOW_ETH_BALANCE_THRESHOLD_ARBITRUM,
-  BATCH_POSTING_TIMEBOUNDS_FALLBACK,
   getMaxBlockRange,
   MAX_TIMEBOUNDS_SECONDS,
-  getParentChainBlockTimeForBatchPosting,
+  BATCH_POSTING_TIMEBOUNDS_FALLBACK,
   BATCH_POSTING_TIMEBOUNDS_BUFFER,
+  getParentChainBlockTimeForBatchPosting,
 } from './chains'
 import { BatchPosterMonitorOptions } from './types'
 import { reportBatchPosterErrorToSlack } from './reportBatchPosterAlertToSlack'

--- a/packages/batch-poster-monitor/index.ts
+++ b/packages/batch-poster-monitor/index.ts
@@ -106,23 +106,34 @@ const sequencerBatchDeliveredEventAbi: AbiEvent = {
   type: 'event',
 }
 
-const displaySummaryInformation = (
-  childChainInformation: ChainInfo,
-  latestBatchPostedBlockNumber: bigint,
-  latestBatchPostedSecondsAgo: bigint,
-  latestChildChainBlockNumber: bigint,
-  batchPosterBacklogSize: bigint,
+const displaySummaryInformation = ({
+  childChainInformation,
+  lastBlockReported,
+  latestBatchPostedBlockNumber,
+  latestBatchPostedSecondsAgo,
+  latestChildChainBlockNumber,
+  batchPosterBacklogSize,
+  batchPostingTimeBounds,
+}: {
+  childChainInformation: ChainInfo
+  lastBlockReported: bigint
+  latestBatchPostedBlockNumber: bigint
+  latestBatchPostedSecondsAgo: bigint
+  latestChildChainBlockNumber: bigint
+  batchPosterBacklogSize: bigint
   batchPostingTimeBounds: number
-) => {
+}) => {
   console.log('**********')
   console.log(`Batch poster summary of [${childChainInformation.name}]`)
   console.log(
     `Latest block number on [${childChainInformation.name}] is ${latestChildChainBlockNumber}.`
   )
   console.log(
-    `Latest batch posted on [Parent chain id: ${
+    `Latest [${
+      childChainInformation.name
+    }] block included on [Parent chain id: ${
       childChainInformation.parentChainId
-    }] is ${latestBatchPostedBlockNumber} => ${
+    }, block-number ${latestBatchPostedBlockNumber}] is ${lastBlockReported} => ${
       latestBatchPostedSecondsAgo / 60n / 60n
     } hours, ${(latestBatchPostedSecondsAgo / 60n) % 60n} minutes, ${
       latestBatchPostedSecondsAgo % 60n
@@ -485,14 +496,15 @@ const monitorBatchPoster = async (childChainInformation: ChainInfo) => {
     return
   }
 
-  displaySummaryInformation(
+  displaySummaryInformation({
     childChainInformation,
-    lastSequencerInboxBlock.number,
-    secondsSinceLastBatchPoster,
+    lastBlockReported,
+    latestBatchPostedBlockNumber: lastSequencerInboxBlock.number,
+    latestBatchPostedSecondsAgo: secondsSinceLastBatchPoster,
     latestChildChainBlockNumber,
-    batchPosterBacklog,
-    batchPostingTimeBounds
-  )
+    batchPosterBacklogSize: batchPosterBacklog,
+    batchPostingTimeBounds,
+  })
 }
 
 const main = async () => {

--- a/packages/batch-poster-monitor/index.ts
+++ b/packages/batch-poster-monitor/index.ts
@@ -130,11 +130,7 @@ const displaySummaryInformation = (
   )
 
   console.log(`Batch poster backlog is ${batchPosterBacklogSize} blocks.`)
-  console.log(
-    `At least 1 batch is expected to be posted every ${
-      batchPostingTimeBounds / 60 / 60
-    } hours.`
-  )
+  console.log(timeBoundsExpectedMessage(batchPostingTimeBounds))
   console.log('**********')
   console.log('')
 }
@@ -310,6 +306,11 @@ const getBatchPostingTimeBounds = async (
   )
 }
 
+const timeBoundsExpectedMessage = (batchPostingTimebounds: number) =>
+  `At least 1 batch is expected to be posted every ${
+    batchPostingTimebounds / 60 / 60
+  } hours.`
+
 const monitorBatchPoster = async (childChainInformation: ChainInfo) => {
   const alertsForChildChain: string[] = []
 
@@ -397,6 +398,7 @@ const monitorBatchPoster = async (childChainInformation: ChainInfo) => {
   const latestChildChainBlockNumber = await childChainClient.getBlockNumber()
 
   if (!sequencerInboxLogs || sequencerInboxLogs.length === 0) {
+    // get the last block that is 'safe' ie. can be assumed to have been posted
     const latestChildChainSafeBlock = await childChainClient.getBlock({
       blockTag: 'safe',
     })
@@ -421,9 +423,7 @@ const monitorBatchPoster = async (childChainInformation: ChainInfo) => {
           MAX_TIMEBOUNDS_SECONDS / 60 / 60
         } hours, and last block number (${latestChildChainBlockNumber}) is greater than the last safe block number (${
           latestChildChainSafeBlock.number
-        }). At least 1 batch is expected to be posted every ${
-          batchPostingTimeBounds / 60 / 60
-        } hours.`
+        }). ${timeBoundsExpectedMessage(batchPostingTimeBounds)}`
       )
 
       showAlert(childChainInformation, alertsForChildChain)
@@ -438,7 +438,6 @@ const monitorBatchPoster = async (childChainInformation: ChainInfo) => {
         } hours, and hence no batch has been posted.\n`
       )
     }
-
     return
   }
 
@@ -476,9 +475,9 @@ const monitorBatchPoster = async (childChainInformation: ChainInfo) => {
         secondsSinceLastBatchPoster / 60n / 60n
       } hours and ${
         (secondsSinceLastBatchPoster / 60n) % 60n
-      } mins ago, and there's a backlog of ${batchPosterBacklog} blocks in the chain. At least 1 batch is expected to be posted every ${
-        batchPostingTimeBounds / 60 / 60
-      } hours.`
+      } mins ago, and there's a backlog of ${batchPosterBacklog} blocks in the chain. ${timeBoundsExpectedMessage(
+        batchPostingTimeBounds
+      )}`
     )
   }
 


### PR DESCRIPTION
Currently, our batch poster monitors for a fixed duration of 4 hours if a batch has not been posted on parent-chain. With this PR, we now make this range dynamic because it depends on the `maxTimeVariation` set for the chain.

Closes FS-719