### PR TITLE
fix: skip anytrust check for core chains

### DIFF
--- a/packages/batch-poster-monitor/chains.ts
+++ b/packages/batch-poster-monitor/chains.ts
@@ -31,6 +31,8 @@ export const supportedParentChains = [
   baseSepolia,
 ]
 
+export const ignoreAnyTrustCheckChainIds = [42161, 42170]
+
 export const getChainFromId = (chainId: number): Chain => {
   const chain = supportedParentChains.filter(chain => chain.id === chainId)
   return chain[0] ?? null

--- a/packages/batch-poster-monitor/chains.ts
+++ b/packages/batch-poster-monitor/chains.ts
@@ -31,7 +31,9 @@ export const supportedParentChains = [
   baseSepolia,
 ]
 
-export const ignoreAnyTrustCheckChainIds = [42161, 42170]
+// ignore trust check for core chains
+export const ignoreAnyTrustCheckForChainIds: number[] =
+  supportedParentChains.map(chain => chain.id)
 
 export const getChainFromId = (chainId: number): Chain => {
   const chain = supportedParentChains.filter(chain => chain.id === chainId)

--- a/packages/batch-poster-monitor/index.ts
+++ b/packages/batch-poster-monitor/index.ts
@@ -9,7 +9,6 @@ import {
   http,
   parseAbi,
 } from 'viem'
-import { arbitrum, arbitrumNova } from 'viem/chains'
 import { AbiEvent } from 'abitype'
 import { getBatchPosters, isAnyTrust } from '@arbitrum/orbit-sdk'
 import {
@@ -22,7 +21,7 @@ import {
   MIN_DAYS_OF_BALANCE_LEFT,
   MAX_LOGS_TO_PROCESS_FOR_BALANCE,
   BATCH_POSTER_BALANCE_ALERT_THRESHOLD_FALLBACK,
-  ignoreAnyTrustCheckChainIds,
+  ignoreAnyTrustCheckForChainIds,
 } from './chains'
 import { BatchPosterMonitorOptions } from './types'
 import { reportBatchPosterErrorToSlack } from './reportBatchPosterAlertToSlack'
@@ -567,7 +566,7 @@ const monitorBatchPoster = async (childChainInformation: ChainInfo) => {
   const lastSequencerInboxLog = sequencerInboxLogs.pop()
 
   const isChainAnyTrust =
-    !ignoreAnyTrustCheckChainIds.includes(childChain.id) &&
+    !ignoreAnyTrustCheckForChainIds.includes(childChain.id) &&
     (await isAnyTrust({
       publicClient: parentChainClient as any,
       rollup: childChainInformation.ethBridge.rollup as `0x${string}`,

--- a/packages/batch-poster-monitor/index.ts
+++ b/packages/batch-poster-monitor/index.ts
@@ -22,6 +22,7 @@ import {
   MIN_DAYS_OF_BALANCE_LEFT,
   MAX_LOGS_TO_PROCESS_FOR_BALANCE,
   BATCH_POSTER_BALANCE_ALERT_THRESHOLD_FALLBACK,
+  ignoreAnyTrustCheckChainIds,
 } from './chains'
 import { BatchPosterMonitorOptions } from './types'
 import { reportBatchPosterErrorToSlack } from './reportBatchPosterAlertToSlack'
@@ -566,8 +567,7 @@ const monitorBatchPoster = async (childChainInformation: ChainInfo) => {
   const lastSequencerInboxLog = sequencerInboxLogs.pop()
 
   const isChainAnyTrust =
-    childChain.id !== arbitrum.id &&
-    childChain.id !== arbitrumNova.id &&
+    !ignoreAnyTrustCheckChainIds.includes(childChain.id) &&
     (await isAnyTrust({
       publicClient: parentChainClient as any,
       rollup: childChainInformation.ethBridge.rollup as `0x${string}`,


### PR DESCRIPTION
Calling `orbit-sdk > isAnyTrust()` method on core-chains results in this error: 

```Error processing chain: Expected to find 1 RollupInitialized event for rollup address 0x5eF0D09d1E6204141B4d37530808eD19f60FBa35 but found 0```

To fix this, we're skipping ArbOne and Nova chain for this check in the monitor.