### PR TITLE
fix: notion monitoring regression issues

### DIFF
--- a/packages/batch-poster-monitor/index.ts
+++ b/packages/batch-poster-monitor/index.ts
@@ -41,6 +41,7 @@ const options: BatchPosterMonitorOptions = yargs(process.argv.slice(2))
   .options({
     configPath: { type: 'string', default: DEFAULT_CONFIG_PATH },
     enableAlerting: { type: 'boolean', default: false },
+    writeToNotion: { type: 'boolean', default: false },
   })
   .strict()
   .parseSync() as BatchPosterMonitorOptions

--- a/packages/retryable-monitor/index.ts
+++ b/packages/retryable-monitor/index.ts
@@ -2,7 +2,10 @@ import * as fs from 'fs'
 import yargs from 'yargs'
 import winston from 'winston'
 import { providers } from 'ethers'
-import { getArbitrumNetwork } from '@arbitrum/sdk'
+import {
+  getArbitrumNetwork,
+  registerCustomArbitrumNetwork,
+} from '@arbitrum/sdk'
 import { FindRetryablesOptions } from './core/types'
 import { ChildNetwork, DEFAULT_CONFIG_PATH, getConfig } from '../utils'
 import {
@@ -137,12 +140,17 @@ const processOrbitChainsConcurrently = async () => {
 
   const promises = config.childChains.map(async (childChain: ChildNetwork) => {
     try {
+      if (!networkIsRegistered(childChain.chainId)) {
+        registerCustomArbitrumNetwork(childChain)
+      }
+
       const parentChainProvider = new providers.JsonRpcProvider(
         String(childChain.parentRpcUrl)
       )
       const childChainProvider = new providers.JsonRpcProvider(
         String(childChain.orbitRpcUrl)
       )
+
       return await processChildChain(
         parentChainProvider,
         childChainProvider,


### PR DESCRIPTION
- `--writeToNotion` flag needs to be type-safe with all monitors
- registering custom arbitrum networks was somehow skipped in the previous PR