### PR TITLE
Set default Decision field for new retryables

### DIFF
--- a/packages/retryable-monitor/core/retryableChecker.ts
+++ b/packages/retryable-monitor/core/retryableChecker.ts
@@ -97,7 +97,7 @@ export const checkRetryables = async (
               ParentTx: `${PARENT_CHAIN_TX_PREFIX}${parentTxHash}`,
               createdAt: Date.now(), // fallback; won't overwrite real one
               timeout: Date.now() + SEVEN_DAYS_IN_SECONDS * 1000,
-              status: 'Resolved',
+              status: 'Executed',
               priority: 'Unset',
               metadata: {
                 tokensDeposited: undefined,

--- a/packages/retryable-monitor/core/types.ts
+++ b/packages/retryable-monitor/core/types.ts
@@ -78,6 +78,7 @@ export interface OnRetryableFoundParams {
     gasPriceNow: string
     l2CallValue: string
     createdAt?: number
+    decision?: string
   }
 }
 

--- a/packages/retryable-monitor/core/types.ts
+++ b/packages/retryable-monitor/core/types.ts
@@ -64,7 +64,7 @@ export interface OnRetryableFoundParams {
   ParentTx: string
   createdAt: number
   timeout?: number
-  status?:string
+  status:string
   priority?: 'High' | 'Medium' | 'Low' | 'Unset'
   decision?: string
   metadata?: {

--- a/packages/retryable-monitor/core/types.ts
+++ b/packages/retryable-monitor/core/types.ts
@@ -66,6 +66,7 @@ export interface OnRetryableFoundParams {
   timeout?: number
   status?:string
   priority?: 'High' | 'Medium' | 'Low' | 'Unset'
+  decision?: string
   metadata?: {
     tokensDeposited?: string
     gasPriceProvided: string
@@ -74,6 +75,7 @@ export interface OnRetryableFoundParams {
     l2CallValue: string
     createdAt?: number
     decision?: string
+    
   }
 }
 

--- a/packages/retryable-monitor/core/types.ts
+++ b/packages/retryable-monitor/core/types.ts
@@ -64,12 +64,7 @@ export interface OnRetryableFoundParams {
   ParentTx: string
   createdAt: number
   timeout?: number
-  status?:
-    | 'Untriaged'
-    | 'Investigating'
-    | 'Resolved'
-    | 'False Positive'
-    | 'Expired'
+  status?:string
   priority?: 'High' | 'Medium' | 'Low' | 'Unset'
   metadata?: {
     tokensDeposited?: string

--- a/packages/retryable-monitor/handlers/handleFailedRetryablesFound.ts
+++ b/packages/retryable-monitor/handlers/handleFailedRetryablesFound.ts
@@ -81,7 +81,7 @@ export const handleFailedRetryablesFound = async (
       ParentTx: `${PARENT_CHAIN_TX_PREFIX}${parentChainRetryableReport.transactionHash}`,
       createdAt: Number(childChainRetryableReport.createdAtTimestamp) * 1000,
       timeout: Number(childChainRetryableReport.timeoutTimestamp) * 1000,
-      status: 'Untriaged',
+      status: childChainRetryableReport.status,
       priority: 'Unset',
       metadata: {
         tokensDeposited: formattedTokenString,

--- a/packages/retryable-monitor/handlers/handleFailedRetryablesFound.ts
+++ b/packages/retryable-monitor/handlers/handleFailedRetryablesFound.ts
@@ -89,6 +89,7 @@ export const handleFailedRetryablesFound = async (
         gasPriceAtCreation,
         gasPriceNow,
         l2CallValue: l2CallValueFormatted,
+        decision: 'Triage'
       },
     })
   }

--- a/packages/retryable-monitor/handlers/notion/syncRetryableToNotion.ts
+++ b/packages/retryable-monitor/handlers/notion/syncRetryableToNotion.ts
@@ -42,7 +42,6 @@ export async function syncRetryableToNotion(
       // Still too big: milliseconds → use as-is
       createdAtMs = rawCreatedAt
     } else if (rawCreatedAt > 1e10) {
-
       createdAtMs = rawCreatedAt
     } else {
       // Normal seconds → convert to ms
@@ -81,6 +80,11 @@ export async function syncRetryableToNotion(
       if (metadata.tokensDeposited) {
         notionProps['TokensDeposited'] = {
           rich_text: [{ text: { content: metadata.tokensDeposited } }],
+        }
+      }
+      if (metadata.decision) {
+        notionProps['Decision'] = {
+          select: { name: metadata.decision },
         }
       }
     }
@@ -150,6 +154,7 @@ export async function syncRetryableToNotion(
       properties: {
         ChildTx: { title: [{ text: { content: ChildTx } }] },
         Status: { select: { name: status } },
+        Decision: { select: { name: 'Triage' } },
         ...notionProps,
       },
     })

--- a/packages/retryable-monitor/handlers/notion/syncRetryableToNotion.ts
+++ b/packages/retryable-monitor/handlers/notion/syncRetryableToNotion.ts
@@ -31,22 +31,18 @@ export async function syncRetryableToNotion(
     const isRetryableFoundInNotion = search.results.length > 0
 
     const rawCreatedAt = metadata?.createdAt ?? createdAt
-
-    // Normalize to milliseconds (ms) — only if needed
     let createdAtMs: number
 
     if (rawCreatedAt > 1e14) {
-      // Too big: microseconds → convert to ms
       createdAtMs = Math.floor(rawCreatedAt / 1000)
     } else if (rawCreatedAt > 1e12) {
-      // Still too big: milliseconds → use as-is
       createdAtMs = rawCreatedAt
     } else if (rawCreatedAt > 1e10) {
       createdAtMs = rawCreatedAt
     } else {
-      // Normal seconds → convert to ms
       createdAtMs = rawCreatedAt * 1000
     }
+
     const notionProps: Record<string, any> = {
       ParentTx: { rich_text: [{ text: { content: ParentTx } }] },
       CreatedAt: {
@@ -56,6 +52,7 @@ export async function syncRetryableToNotion(
       },
       Priority: { select: { name: priority } },
     }
+
     if (input.timeout) {
       notionProps['timeoutTimestamp'] = {
         date: { start: new Date(input.timeout).toISOString() },
@@ -67,9 +64,7 @@ export async function syncRetryableToNotion(
         rich_text: [{ text: { content: metadata.gasPriceProvided } }],
       }
       notionProps['GasPriceAtCreation'] = {
-        rich_text: [
-          { text: { content: metadata.gasPriceAtCreation ?? 'N/A' } },
-        ],
+        rich_text: [{ text: { content: metadata.gasPriceAtCreation ?? 'N/A' } }],
       }
       notionProps['GasPriceNow'] = {
         rich_text: [{ text: { content: metadata.gasPriceNow } }],
@@ -107,30 +102,37 @@ export async function syncRetryableToNotion(
         currentStatus = statusProp.select.name
       }
 
-      if (status === 'Resolved') {
-        const resolvedProps: Record<string, any> = {
-          Status: { select: { name: 'Resolved' } },
+      // ✅ Handle Executed updates
+      if (status === 'Executed') {
+        const executedProps: Record<string, any> = {
+          Status: { select: { name: 'Executed' } },
         }
 
         if (input.timeout) {
-          resolvedProps['timeoutTimestamp'] = {
+          executedProps['timeoutTimestamp'] = {
             date: { start: new Date(input.timeout).toISOString() },
+          }
+        }
+
+        if (metadata?.decision) {
+          executedProps['Decision'] = {
+            select: { name: metadata.decision },
           }
         }
 
         return await notionClient.pages
           .update({
             page_id: page.id,
-            properties: resolvedProps,
+            properties: executedProps,
           })
           .then(() => ({
             id: page.id,
-            status: 'Resolved',
+            status: 'Executed',
             isNew: false,
           }))
       }
 
-      // Only overwrite status if still Untriaged or missing
+      // Overwrite status only if it's Untriaged or missing
       if (currentStatus === 'Untriaged' || !currentStatus) {
         notionProps['Status'] = { select: { name: status } }
       }
@@ -143,20 +145,32 @@ export async function syncRetryableToNotion(
       return { id: page.id, status: currentStatus ?? status, isNew: false }
     }
 
-    if (!isRetryableFoundInNotion && status === 'Resolved') {
-      // Resolved but not found—skip
-      return undefined
-    }
+    if (!isRetryableFoundInNotion) {
+  if (status === 'Executed') {
+    return undefined // Skip creating Executed-only entries
+  }
 
-    // Retryable is new and unresolved—create full entry
+  const created = await notionClient.pages.create({
+    parent: { database_id: databaseId },
+    properties: {
+      ChildTx: { title: [{ text: { content: ChildTx } }] },
+      Status: { select: { name: status } },
+      ...notionProps,
+    },
+  })
+
+  return { id: created.id, status, isNew: true }
+}
+
+    // Create new entry
     const created = await notionClient.pages.create({
-  parent: { database_id: databaseId },
-  properties: {
-    ChildTx: { title: [{ text: { content: ChildTx } }] },
-    Status: { select: { name: status } },
-    ...notionProps,
-  },
-})
+      parent: { database_id: databaseId },
+      properties: {
+        ChildTx: { title: [{ text: { content: ChildTx } }] },
+        Status: { select: { name: status } },
+        ...notionProps,
+      },
+    })
 
     return { id: created.id, status, isNew: true }
   } catch (err) {

--- a/packages/retryable-monitor/handlers/notion/syncRetryableToNotion.ts
+++ b/packages/retryable-monitor/handlers/notion/syncRetryableToNotion.ts
@@ -12,7 +12,7 @@ export async function syncRetryableToNotion(
     ChildTx,
     ParentTx,
     createdAt,
-    status = 'Untriaged',
+    status,
     priority = 'Unset',
     metadata,
   } = input
@@ -31,25 +31,18 @@ export async function syncRetryableToNotion(
     const isRetryableFoundInNotion = search.results.length > 0
 
     const rawCreatedAt = metadata?.createdAt ?? createdAt
-    let createdAtMs: number
-
-    if (rawCreatedAt > 1e14) {
-      createdAtMs = Math.floor(rawCreatedAt / 1000)
-    } else if (rawCreatedAt > 1e12) {
-      createdAtMs = rawCreatedAt
-    } else if (rawCreatedAt > 1e10) {
-      createdAtMs = rawCreatedAt
-    } else {
-      createdAtMs = rawCreatedAt * 1000
-    }
+    const createdAtMs =
+      rawCreatedAt > 1e14
+        ? Math.floor(rawCreatedAt / 1000)
+        : rawCreatedAt > 1e12
+        ? rawCreatedAt
+        : rawCreatedAt > 1e10
+        ? rawCreatedAt
+        : rawCreatedAt * 1000
 
     const notionProps: Record<string, any> = {
       ParentTx: { rich_text: [{ text: { content: ParentTx } }] },
-      CreatedAt: {
-        date: {
-          start: new Date(createdAtMs).toISOString(),
-        },
-      },
+      CreatedAt: { date: { start: new Date(createdAtMs).toISOString() } },
       Priority: { select: { name: priority } },
     }
 
@@ -77,11 +70,6 @@ export async function syncRetryableToNotion(
           rich_text: [{ text: { content: metadata.tokensDeposited } }],
         }
       }
-      if (metadata.decision) {
-        notionProps['Decision'] = {
-          select: { name: metadata.decision },
-        }
-      }
     }
 
     if (isRetryableFoundInNotion) {
@@ -96,11 +84,16 @@ export async function syncRetryableToNotion(
 
       const props = (page as PageObjectResponse).properties
       const statusProp = props?.Status
+      const decisionProp = props?.Decision
 
-      let currentStatus: string | undefined = undefined
-      if (statusProp && statusProp.type === 'select' && statusProp.select) {
-        currentStatus = statusProp.select.name
-      }
+      const currentStatus =
+        statusProp?.type === 'select' && statusProp.select
+          ? statusProp.select.name
+          : undefined
+      const currentDecision =
+        decisionProp?.type === 'select' && decisionProp.select
+          ? decisionProp.select.name
+          : undefined
 
       // ✅ Handle Executed updates
       if (status === 'Executed') {
@@ -114,27 +107,27 @@ export async function syncRetryableToNotion(
           }
         }
 
-        if (metadata?.decision) {
+        if (!currentDecision && metadata?.decision) {
           executedProps['Decision'] = {
             select: { name: metadata.decision },
           }
         }
 
-        return await notionClient.pages
-          .update({
-            page_id: page.id,
-            properties: executedProps,
-          })
-          .then(() => ({
-            id: page.id,
-            status: 'Executed',
-            isNew: false,
-          }))
+        await notionClient.pages.update({
+          page_id: page.id,
+          properties: executedProps,
+        })
+
+        return { id: page.id, status: 'Executed', isNew: false }
       }
 
-      // Overwrite status only if it's Untriaged or missing
-      if (currentStatus === 'Untriaged' || !currentStatus) {
-        notionProps['Status'] = { select: { name: status } }
+      notionProps['Status'] = { select: { name: status } }
+
+      // Only set Decision if it's missing
+      if (!currentDecision && metadata?.decision) {
+        notionProps['Decision'] = {
+          select: { name: metadata.decision },
+        }
       }
 
       await notionClient.pages.update({
@@ -145,29 +138,17 @@ export async function syncRetryableToNotion(
       return { id: page.id, status: currentStatus ?? status, isNew: false }
     }
 
-    if (!isRetryableFoundInNotion) {
-  if (status === 'Executed') {
-    return undefined // Skip creating Executed-only entries
-  }
+    // If not found and Executed, skip creation
+    if (!isRetryableFoundInNotion && status === 'Executed') {
+      return undefined
+    }
 
-  const created = await notionClient.pages.create({
-    parent: { database_id: databaseId },
-    properties: {
-      ChildTx: { title: [{ text: { content: ChildTx } }] },
-      Status: { select: { name: status } },
-      ...notionProps,
-    },
-  })
-
-  return { id: created.id, status, isNew: true }
-}
-
-    // Create new entry
     const created = await notionClient.pages.create({
       parent: { database_id: databaseId },
       properties: {
         ChildTx: { title: [{ text: { content: ChildTx } }] },
         Status: { select: { name: status } },
+        ...(metadata?.decision ? { Decision: { select: { name: metadata.decision } } } : {}),
         ...notionProps,
       },
     })

--- a/packages/retryable-monitor/handlers/notion/syncRetryableToNotion.ts
+++ b/packages/retryable-monitor/handlers/notion/syncRetryableToNotion.ts
@@ -150,14 +150,13 @@ export async function syncRetryableToNotion(
 
     // Retryable is new and unresolved—create full entry
     const created = await notionClient.pages.create({
-      parent: { database_id: databaseId },
-      properties: {
-        ChildTx: { title: [{ text: { content: ChildTx } }] },
-        Status: { select: { name: status } },
-        Decision: { select: { name: 'Triage' } },
-        ...notionProps,
-      },
-    })
+  parent: { database_id: databaseId },
+  properties: {
+    ChildTx: { title: [{ text: { content: ChildTx } }] },
+    Status: { select: { name: status } },
+    ...notionProps,
+  },
+})
 
     return { id: created.id, status, isNew: true }
   } catch (err) {


### PR DESCRIPTION
### Key Changes to `syncRetryableToNotion`

**1. New Behavior for `Status` Field**

- We now treat `Status` as fully derived from on-chain data.

- It gets auto-populated with one of: "Pending", "Executed", or "Expired", depending on the retryable's state.

- We removed any assumption that "Untriaged" is a valid default — it's no longer used anywhere.

**2. New Behavior for Decision Field**

- `Decision` is now treated as a manual triage decision.

- The sync logic only sets `Decision` if it’s currently unset in Notion.

- This prevents us from overwriting human decisions like switching "Triage" to "Redeem".

**3. Executed Tickets Are Handled Separately**

- If the ticket is marked as "Executed", we now:

            - Skip creation if the ticket is not already in Notion.

            - Update its `Status` to "Executed" if already in the DB.

             - Only write to `Decision` if it's still blank.

### Slack Alert Improvements

- The alert script now sends Slack messages only for retryables with:

- `Decision` = `Triage` or `Decision` = `Should Redeem`

- It skips any ticket where `Status` = `Executed`, to avoid noise.

- It also no longer alerts on "`Untriaged`" since that status alerting is deprecated.