### PR TITLE
Add ChainID support for filtering Notion alerts

### DIFF
--- a/packages/retryable-monitor/core/retryableChecker.ts
+++ b/packages/retryable-monitor/core/retryableChecker.ts
@@ -99,6 +99,7 @@ export const checkRetryables = async (
               timeout: Date.now() + SEVEN_DAYS_IN_SECONDS * 1000,
               status: 'Executed',
               priority: 'Unset',
+              chainId: childChain.chainId,
               metadata: {
                 tokensDeposited: undefined,
                 gasPriceProvided: '-',

--- a/packages/retryable-monitor/core/types.ts
+++ b/packages/retryable-monitor/core/types.ts
@@ -67,6 +67,7 @@ export interface OnRetryableFoundParams {
   status:string
   priority?: 'High' | 'Medium' | 'Low' | 'Unset'
   decision?: string
+  chainId: number
   metadata?: {
     tokensDeposited?: string
     gasPriceProvided: string

--- a/packages/retryable-monitor/handlers/notion/alertUntriagedRetraybles.ts
+++ b/packages/retryable-monitor/handlers/notion/alertUntriagedRetraybles.ts
@@ -24,7 +24,7 @@ const isNearExpiry = (iso: string | undefined, hours = 24) => {
   return timeLeftMs > 0 && timeLeftMs <= hours * 60 * 60 * 1000
 }
 
-export const alertUntriagedNotionRetryables = async () => {
+export const alertUntriagedNotionRetryables = async (allowedChainIds: number[] = []) => {
   const response = await notionClient.databases.query({
     database_id: databaseId,
     page_size: 100,
@@ -46,17 +46,21 @@ export const alertUntriagedNotionRetryables = async () => {
 
   for (const page of response.results) {
     const props = (page as any).properties
+
+    // skip if chainId not in allowed list
+    const chainIdRaw = props?.ChainID?.number
+    if (allowedChainIds.length > 0 && !allowedChainIds.includes(chainIdRaw)) {
+      continue
+    }
+
     const status = props?.Status?.select?.name || '(unknown)'
     if (status?.toLowerCase() === 'expired') continue
 
     const timeoutRaw = props?.timeoutTimestamp?.date?.start
     const timeoutStr = formatDate(timeoutRaw)
-    const retryableUrl =
-      props?.ChildTx?.title?.[0]?.text?.content || '(unknown)'
-    const parentTx =
-      props?.ParentTx?.rich_text?.[0]?.text?.content || '(unknown)'
-    const deposit =
-      props?.TotalRetryableDeposit?.rich_text?.[0]?.text?.content || '(unknown)'
+    const retryableUrl = props?.ChildTx?.title?.[0]?.text?.content || '(unknown)'
+    const parentTx = props?.ParentTx?.rich_text?.[0]?.text?.content || '(unknown)'
+    const deposit = props?.TotalRetryableDeposit?.rich_text?.[0]?.text?.content || '(unknown)'
     const decision = props?.Decision?.select?.name || '(unknown)'
 
     const now = Date.now()

--- a/packages/retryable-monitor/handlers/notion/syncRetryableToNotion.ts
+++ b/packages/retryable-monitor/handlers/notion/syncRetryableToNotion.ts
@@ -44,6 +44,7 @@ export async function syncRetryableToNotion(
       ParentTx: { rich_text: [{ text: { content: ParentTx } }] },
       CreatedAt: { date: { start: new Date(createdAtMs).toISOString() } },
       Priority: { select: { name: priority } },
+      ChainID: { number: input.chainId },
     }
 
     if (input.timeout) {

--- a/packages/retryable-monitor/index.ts
+++ b/packages/retryable-monitor/index.ts
@@ -177,9 +177,11 @@ const processOrbitChainsConcurrently = async () => {
 
   // once we process all the chains go through the Notion database once to alert on any `Unresolved` tickets found
   if (options.writeToNotion) {
-    await alertUntriagedNotionRetryables()
+    const allowedChainIds = config.childChains.map((c: ChildNetwork) => c.chainId)
+    await alertUntriagedNotionRetryables(allowedChainIds)
   }
 }
+
 
 // Start processing child chains concurrently
 processOrbitChainsConcurrently()


### PR DESCRIPTION
This PR updates `alertUntriagedNotionRetryables` to accept `allowedChainIds` and skip tickets whose `ChainID` does not match. This ensures alerts are only triggered for chains listed in the config.
In `processOrbitChainsConcurrently`, chain IDs are collected from `config.childChains` and passed to `alertUntriagedNotionRetryables`.