### PR TITLE
feat: adds 'all' to ignore chains in poster

### DIFF
--- a/packages/batch-poster-monitor/README.md
+++ b/packages/batch-poster-monitor/README.md
@@ -82,18 +82,20 @@ The monitor generates alerts in these critical scenarios:
 
 ### Ignore List
 
-The monitor can ignore specific transaction types based on their function selectors. This is configured in `packages/batch-poster-monitor/ignoreList.ts`:
+The monitor can ignore specific transaction types or entire chains based on configuration in `packages/batch-poster-monitor/ignoreList.ts`:
 
 ```typescript
 const defaultIgnoreList: Record<number, string[]> = {
   51828: ['0x8d80ff0a'], // ChainBounty - ignores multiSend(bytes) transactions
+  51829: ['all'],        // Ignore entire chain
 }
 ```
 
 The ignore system works by:
 - Checking the first 4 bytes (function selector) of each transaction
 - Skipping monitoring if the selector is in the ignore list for that chain
-- Logging when transactions are ignored: `Chain [ChainName]: Ignoring transaction with function selector 0x...`
+- Using `'all'` to ignore an entire chain completely
+- Logging when transactions/chains are ignored
 
 Common function selectors:
 - `0x8d80ff0a` - multiSend(bytes) - Used by multi-signature wallets for batch transactions
@@ -101,6 +103,7 @@ Common function selectors:
 This is useful for:
 - Chains using multi-sig wallets for batch posting
 - Ignoring specific transaction types that don't require monitoring
+- Temporarily disabling monitoring for entire chains
 - Reducing false positive alerts from expected transaction patterns
 
 Each alert includes:

--- a/packages/batch-poster-monitor/__test__/batch-poster.test.ts
+++ b/packages/batch-poster-monitor/__test__/batch-poster.test.ts
@@ -1,5 +1,5 @@
-import { beforeAll, describe, expect, test, vi } from 'vitest'
-import { setIgnoreList, shouldIgnoreFunctionSelector, isIgnoredSelectorError } from '../ignoreList'
+import { beforeAll, beforeEach, describe, expect, test, vi } from 'vitest'
+import { setIgnoreList, shouldIgnoreFunctionSelector, isIgnoredSelectorError, shouldIgnoreChain } from '../ignoreList'
 import { createTestChainConfig } from './testConfigs'
 
 const VIEM_DECODE_ERROR_MESSAGE = (selector: string) => 
@@ -70,5 +70,36 @@ describe('Ignore List System', () => {
     })
     
     expect(alerts).toEqual([])
+  })
+})
+
+describe('Chain-level Ignore with "all"', () => {
+  beforeEach(() => {
+    setIgnoreList({})
+  })
+
+  test('should ignore entire chains configured with "all"', () => {
+    setIgnoreList({
+      12345: ['all'],
+      67890: ['0x12345678'],
+    })
+    
+    expect(shouldIgnoreChain(12345)).toBe(true)   // Has 'all'
+    expect(shouldIgnoreChain(67890)).toBe(false)  // Doesn't have 'all'
+    expect(shouldIgnoreFunctionSelector(12345, 'any-selector')).toBe(true)  // Any selector ignored
+  })
+
+  test('should work alongside function selector ignores', () => {
+    setIgnoreList({
+      42161: ['0x8d80ff0a'],  // Function selector only
+      421614: ['all'],        // Entire chain
+    })
+    
+    expect(shouldIgnoreChain(42161)).toBe(false)
+    expect(shouldIgnoreFunctionSelector(42161, '0x8d80ff0a')).toBe(true)
+    expect(shouldIgnoreFunctionSelector(42161, '0xother')).toBe(false)
+    
+    expect(shouldIgnoreChain(421614)).toBe(true)
+    expect(shouldIgnoreFunctionSelector(421614, 'any-selector')).toBe(true)
   })
 })

--- a/packages/batch-poster-monitor/ignoreList.ts
+++ b/packages/batch-poster-monitor/ignoreList.ts
@@ -1,7 +1,7 @@
 // Default ignore list configuration - maps chainId to function selectors or 'all' for entire chain
 const defaultIgnoreList: Record<number, string[]> = {
   51828: ['0x8d80ff0a'], // ChainBounty - multiSend(bytes)
-  421614: ['all'], // Data Lake - ignore entire chain
+  140: ['all'], // Data Lake - ignore entire chain
 }
 
 let ignoreList: Record<number, string[]> = defaultIgnoreList

--- a/packages/batch-poster-monitor/ignoreList.ts
+++ b/packages/batch-poster-monitor/ignoreList.ts
@@ -1,17 +1,20 @@
-// Default ignore list configuration - maps chainId to function selectors
+// Default ignore list configuration - maps chainId to function selectors or 'all' for entire chain
 const defaultIgnoreList: Record<number, string[]> = {
   51828: ['0x8d80ff0a'], // ChainBounty - multiSend(bytes)
+  421614: ['all'], // Data Lake - ignore entire chain
 }
 
-// Allow override for testing
 let ignoreList: Record<number, string[]> = defaultIgnoreList
 
-// Helper to check if a chain+function selector should be ignored
 export const shouldIgnoreFunctionSelector = (
   chainId: number,
   functionSelector: string
 ): boolean => {
-  return ignoreList[chainId]?.includes(functionSelector) || false
+  return ignoreList[chainId]?.includes(functionSelector) || ignoreList[chainId]?.includes('all') || false
+}
+
+export const shouldIgnoreChain = (chainId: number): boolean => {
+  return shouldIgnoreFunctionSelector(chainId, 'all')
 }
 
 // Helper to check if an error is due to an ignored function selector

--- a/packages/batch-poster-monitor/index.ts
+++ b/packages/batch-poster-monitor/index.ts
@@ -38,6 +38,7 @@ import {
 import {
   shouldIgnoreFunctionSelector,
   isIgnoredSelectorError,
+  shouldIgnoreChain,
 } from './ignoreList'
 
 // Parsing command line arguments using yargs
@@ -682,6 +683,14 @@ const main = async () => {
   // process each chain sequentially to avoid RPC rate limiting
   for (const childChain of config.childChains) {
     try {
+      // Check if entire chain should be ignored (configured with 'all' in ignore list)
+      if (shouldIgnoreChain(childChain.chainId)) {
+        console.log(
+          `Chain [${childChain.name}]: Skipping - configured with 'all' in ignore list`
+        )
+        continue
+      }
+
       console.log('>>>>> Processing chain: ', childChain.name)
       await monitorBatchPoster(childChain)
     } catch (e) {


### PR DESCRIPTION
- adds ability to add `{CHAIN_ID}: 'all'`  to the ignore list to skip a chain entirely in the batch poster monitor.