### PR TITLE
feat(retryable-monitor): digest bursts of funded-ticket alerts

### DIFF
--- a/packages/retryable-monitor/README.md
+++ b/packages/retryable-monitor/README.md
@@ -94,11 +94,11 @@ When used with `--writeToNotion`, Slack alerts are more advanced. See the next s
 
 ### Zero-value ticket digest
 
-Failed tickets with no child chain callvalue and no token deposit carry no user funds and are usually automated system traffic (e.g. keeper contracts on high-volume chains). To avoid flooding Slack, these are not alerted individually — they are batched into a single per-chain digest message (counts by status and sender, earliest expiry, and up to 20 ticket links) posted once the chain has been processed. Tickets with any callvalue or token deposit still get the full per-ticket alert.
+Failed tickets with no child chain callvalue and no token deposit carry no user funds and are usually automated system traffic (e.g. keeper contracts on high-volume chains). To avoid flooding Slack, these are not alerted individually — they are batched into a single per-chain digest message (counts by status and sender, earliest expiry, and up to 10 shortened ticket links) posted once the chain has been processed. Tickets with any callvalue or token deposit still get the full per-ticket alert.
 
 ### Funded ticket digest
 
-Funded tickets (callvalue or token deposit) are buffered during the chain's run and flushed once it completes. Small batches (up to 5 per chain) are posted as the usual detailed per-ticket alerts. Larger bursts — typically a misconfigured depositor bot — are rolled into a single urgent digest instead, containing everything needed to triage: total/average/largest unredeemed amounts (with USD when the chain's gas token is ETH), counts by status and sender, distinct destination count, the expiry window with countdowns, up to 20 ticket links, and a pointer to the run's `retryable-run-report.json` artifact which holds full per-ticket redemption details.
+Funded tickets (callvalue or token deposit) are buffered during the chain's run and flushed once it completes. Small batches (up to 5 per chain) are posted as the usual detailed per-ticket alerts. Larger bursts — typically a misconfigured depositor bot — are rolled into a single urgent digest instead, containing everything needed to triage: total/average/largest unredeemed amounts (with USD when the chain's gas token is ETH), counts by status and sender, distinct destination count, the expiry window with countdowns, up to 10 shortened ticket links, and a pointer to the run's `retryable-run-report.json` artifact which holds full per-ticket redemption details.
 
 ### JSON run report
 

--- a/packages/retryable-monitor/README.md
+++ b/packages/retryable-monitor/README.md
@@ -96,6 +96,10 @@ When used with `--writeToNotion`, Slack alerts are more advanced. See the next s
 
 Failed tickets with no child chain callvalue and no token deposit carry no user funds and are usually automated system traffic (e.g. keeper contracts on high-volume chains). To avoid flooding Slack, these are not alerted individually — they are batched into a single per-chain digest message (counts by status and sender, earliest expiry, and up to 20 ticket links) posted once the chain has been processed. Tickets with any callvalue or token deposit still get the full per-ticket alert.
 
+### Funded ticket digest
+
+Funded tickets (callvalue or token deposit) are buffered during the chain's run and flushed once it completes. Small batches (up to 5 per chain) are posted as the usual detailed per-ticket alerts. Larger bursts — typically a misconfigured depositor bot — are rolled into a single urgent digest instead, containing everything needed to triage: total/average/largest unredeemed amounts (with USD when the chain's gas token is ETH), counts by status and sender, distinct destination count, the expiry window with countdowns, up to 20 ticket links, and a pointer to the run's `retryable-run-report.json` artifact which holds full per-ticket redemption details.
+
 ### JSON run report
 
 Every failed retryable found during a run — including the zero-value ones that only appear in the digest — is written to `retryable-run-report.json` in the package directory. Each entry contains the parent chain transaction hash (the input needed to redeem the ticket), ticket ID, explorer links, sender, destination, value/token data, and expiry. CI can upload this file as a run artifact so tickets can be referenced or redeemed after the run.

--- a/packages/retryable-monitor/__test__/fundedTicketDigest.test.ts
+++ b/packages/retryable-monitor/__test__/fundedTicketDigest.test.ts
@@ -221,9 +221,23 @@ describe('buildFundedDigestMessage', () => {
     const message = await buildFundedDigestMessage(childChain, tickets)
 
     expect(message).toContain('25 unredeemed retryables')
-    expect(message).toContain('0xticket19>')
-    expect(message).not.toContain('0xticket20>')
-    expect(message).toContain('…and 5 more')
+    expect(message).toContain('0xticket9>')
+    expect(message).not.toContain('0xticket10>')
+    expect(message).toContain('…and 15 more')
+  })
+
+  test('shortens long ticket ids and stays under the Slack split threshold', async () => {
+    const mkId = (i: number) =>
+      '0x' + String(i).padStart(2, '0').repeat(32) // realistic 66-char ids
+    const tickets = Array.from({ length: 55 }, (_, i) =>
+      buildTicket({ id: mkId(i) })
+    )
+
+    const message = await buildFundedDigestMessage(childChain, tickets)
+
+    expect(message).toContain(`|0x000000…000000>`)
+    expect(message).toContain(`${mkId(0)}|`) // full URL still present in the link
+    expect(message.length).toBeLessThan(4000)
   })
 
   test('skips USD conversion on custom gas-token chains', async () => {

--- a/packages/retryable-monitor/__test__/fundedTicketDigest.test.ts
+++ b/packages/retryable-monitor/__test__/fundedTicketDigest.test.ts
@@ -16,6 +16,15 @@ vi.mock('../handlers/slack/slackMessageGenerator', () => ({
     .mockResolvedValue('detailed per-ticket alert'),
 }))
 
+vi.mock('@arbitrum/sdk/dist/lib/abi/factories/ERC20__factory', () => ({
+  ERC20__factory: {
+    connect: vi.fn(() => ({
+      symbol: async () => 'XAI',
+      decimals: async () => 6,
+    })),
+  },
+}))
+
 vi.mock('../handlers/slack/slackMessageFormattingUtils', async importOriginal => ({
   ...(await importOriginal<
     typeof import('../handlers/slack/slackMessageFormattingUtils')
@@ -251,6 +260,23 @@ describe('buildFundedDigestMessage', () => {
     ])
 
     expect(message).toContain('*Total unredeemed:* 0.1 gas tokens')
+    expect(message).not.toContain('$')
+  })
+
+  test('uses the gas token symbol and decimals when a parent provider is available', async () => {
+    const gasTokenChain = {
+      ...childChain,
+      nativeToken: '0xgastoken',
+    } as ChildNetwork
+
+    const message = await buildFundedDigestMessage(
+      gasTokenChain,
+      [buildTicket({ l2CallValue: '2500000' })], // 2.5 with the token's 6 decimals
+      {} as any
+    )
+
+    expect(message).toContain('*Total unredeemed:* 2.5 XAI')
+    expect(message).toContain('— 2.5 XAI —')
     expect(message).not.toContain('$')
   })
 })

--- a/packages/retryable-monitor/__test__/fundedTicketDigest.test.ts
+++ b/packages/retryable-monitor/__test__/fundedTicketDigest.test.ts
@@ -1,0 +1,242 @@
+import { describe, expect, test, vi, beforeEach } from 'vitest'
+import { ChildNetwork } from 'utils'
+import {
+  ChildChainTicketReport,
+  OnFailedRetryableFoundParams,
+  ParentChainTicketReport,
+} from '../core/types'
+
+vi.mock('../handlers/slack/postSlackMessage', () => ({
+  postSlackMessage: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('../handlers/slack/slackMessageGenerator', () => ({
+  generateFailedRetryableSlackMessage: vi
+    .fn()
+    .mockResolvedValue('detailed per-ticket alert'),
+}))
+
+vi.mock('../handlers/slack/slackMessageFormattingUtils', async importOriginal => ({
+  ...(await importOriginal<
+    typeof import('../handlers/slack/slackMessageFormattingUtils')
+  >()),
+  getEthPrice: vi.fn().mockResolvedValue(2000),
+}))
+
+import {
+  addTicketToFundedDigest,
+  buildFundedDigestMessage,
+  postFundedTicketAlerts,
+  MAX_INDIVIDUAL_FUNDED_ALERTS,
+} from '../handlers/fundedTicketDigest'
+import { postSlackMessage } from '../handlers/slack/postSlackMessage'
+import { generateFailedRetryableSlackMessage } from '../handlers/slack/slackMessageGenerator'
+
+const nowInSeconds = Math.floor(Date.now() / 1000)
+
+const childChain = {
+  name: 'Test Chain',
+  chainId: 12345,
+  orbitRpcUrl: 'http://localhost:1',
+  parentRpcUrl: 'http://localhost:2',
+  explorerUrl: 'https://child.explorer/',
+  parentExplorerUrl: 'https://parent.explorer/',
+} as ChildNetwork
+
+const buildTicket = ({
+  id = '0xticket',
+  l2CallValue = '100000000000000000', // 0.1 ETH
+  sender = '0xsender',
+  destination = '0xdest',
+  timeoutTimestamp = String(nowInSeconds + 6 * 24 * 60 * 60),
+  tokenAmount,
+}: {
+  id?: string
+  l2CallValue?: string
+  sender?: string
+  destination?: string
+  timeoutTimestamp?: string
+  tokenAmount?: string
+} = {}): OnFailedRetryableFoundParams => ({
+  parentChainRetryableReport: {
+    id: '0xparenttx',
+    transactionHash: '0xparenttx',
+    sender,
+    retryableTicketID: id,
+  } as ParentChainTicketReport,
+  childChainRetryableReport: {
+    id,
+    createdAtTimestamp: String(nowInSeconds - 60 * 60),
+    createdAtBlockNumber: 1,
+    timeoutTimestamp,
+    deposit: l2CallValue,
+    status: 'FUNDS_DEPOSITED_ON_CHILD',
+    retryTo: destination,
+    retryData: '0x',
+    gasFeeCap: 0,
+    gasLimit: 0,
+    l2CallValue,
+  } as ChildChainTicketReport,
+  tokenDepositData: tokenAmount
+    ? {
+        l2TicketId: id,
+        tokenAmount,
+        sender,
+        l1Token: { symbol: 'TST', decimals: 18, id: '0xtoken' },
+      }
+    : undefined,
+  childChain,
+})
+
+describe('postFundedTicketAlerts', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('posts detailed per-ticket alerts for small batches', async () => {
+    for (let i = 0; i < MAX_INDIVIDUAL_FUNDED_ALERTS; i++) {
+      addTicketToFundedDigest(buildTicket({ id: `0xticket${i}` }))
+    }
+
+    await postFundedTicketAlerts(childChain)
+
+    expect(generateFailedRetryableSlackMessage).toHaveBeenCalledTimes(
+      MAX_INDIVIDUAL_FUNDED_ALERTS
+    )
+    expect(postSlackMessage).toHaveBeenCalledTimes(MAX_INDIVIDUAL_FUNDED_ALERTS)
+    expect(postSlackMessage).toHaveBeenCalledWith({
+      message: 'detailed per-ticket alert',
+    })
+  })
+
+  test('posts a single digest for batches above the threshold', async () => {
+    for (let i = 0; i <= MAX_INDIVIDUAL_FUNDED_ALERTS; i++) {
+      addTicketToFundedDigest(buildTicket({ id: `0xticket${i}` }))
+    }
+
+    await postFundedTicketAlerts(childChain)
+
+    expect(generateFailedRetryableSlackMessage).not.toHaveBeenCalled()
+    expect(postSlackMessage).toHaveBeenCalledTimes(1)
+    const message = (postSlackMessage as any).mock.calls[0][0].message
+    expect(message).toContain(
+      `URGENT: ${MAX_INDIVIDUAL_FUNDED_ALERTS + 1} unredeemed retryables with funds at risk`
+    )
+    expect(message).toContain(
+      `Sending a summary instead of individual alerts to avoid spam, since the ticket count exceeds ${MAX_INDIVIDUAL_FUNDED_ALERTS}`
+    )
+  })
+
+  test('flush clears the buffer', async () => {
+    for (let i = 0; i < 3; i++) {
+      addTicketToFundedDigest(buildTicket({ id: `0xticket${i}` }))
+    }
+    await postFundedTicketAlerts(childChain)
+    vi.clearAllMocks()
+
+    await postFundedTicketAlerts(childChain)
+
+    expect(postSlackMessage).not.toHaveBeenCalled()
+  })
+
+  test('no-ops for chains without funded tickets', async () => {
+    await postFundedTicketAlerts(childChain)
+    expect(postSlackMessage).not.toHaveBeenCalled()
+  })
+})
+
+describe('buildFundedDigestMessage', () => {
+  test('summarizes totals, average, largest, senders, destinations and status', async () => {
+    const tickets = [
+      buildTicket({ id: '0xaaa', l2CallValue: '100000000000000000' }),
+      buildTicket({
+        id: '0xbbb',
+        l2CallValue: '300000000000000000',
+        sender: '0xothersender',
+        destination: '0xotherdest',
+      }),
+    ]
+
+    const message = await buildFundedDigestMessage(childChain, tickets)
+
+    expect(message).toContain('*Total unredeemed:* 0.4 ETH (~$800.00)')
+    expect(message).toContain('*Average per ticket:* 0.2 ETH (~$400.00)')
+    expect(message).toContain('*Largest:* 0.3 ETH (~$600.00)')
+    expect(message).toContain('created but not redeemed: 2')
+    expect(message).toContain('0xsender: 1')
+    expect(message).toContain('0xothersender: 1')
+    expect(message).toContain('*Distinct destinations:* 2')
+    expect(message).toContain('https://child.explorer/tx/0xaaa')
+  })
+
+  test('reports the expiry window with a countdown', async () => {
+    const earliest = nowInSeconds + 2 * 24 * 60 * 60 + 60
+    const latest = nowInSeconds + 6 * 24 * 60 * 60 + 60
+    const tickets = [
+      buildTicket({ id: '0xaaa', timeoutTimestamp: String(earliest) }),
+      buildTicket({ id: '0xbbb', timeoutTimestamp: String(latest) }),
+    ]
+
+    const message = await buildFundedDigestMessage(childChain, tickets)
+
+    expect(message).toContain(
+      `earliest ${new Date(earliest * 1000).toUTCString()} (in 2d 0h)`
+    )
+    expect(message).toContain(
+      `latest ${new Date(latest * 1000).toUTCString()} (in 6d 0h)`
+    )
+  })
+
+  test('points to the GitHub Actions artifact when running in CI', async () => {
+    process.env.GITHUB_REPOSITORY = 'OffchainLabs/arbitrum-monitoring'
+    process.env.GITHUB_RUN_ID = '12345'
+    try {
+      const message = await buildFundedDigestMessage(childChain, [buildTicket()])
+      expect(message).toContain(
+        'check the *retryable-run-report.json* artifact on <https://github.com/OffchainLabs/arbitrum-monitoring/actions/runs/12345|this run> urgently'
+      )
+    } finally {
+      delete process.env.GITHUB_REPOSITORY
+      delete process.env.GITHUB_RUN_ID
+    }
+  })
+
+  test('marks tickets that also carry token deposits', async () => {
+    const tickets = [
+      buildTicket({ id: '0xtok', tokenAmount: '1000' }),
+      buildTicket({ id: '0xeth' }),
+    ]
+
+    const message = await buildFundedDigestMessage(childChain, tickets)
+
+    expect(message).toContain('(+1 ticket with token deposits)')
+    expect(message).toContain('0xtok> — 0.1 ETH + tokens')
+  })
+
+  test('caps the listed tickets and reports the overflow count', async () => {
+    const tickets = Array.from({ length: 25 }, (_, i) =>
+      buildTicket({ id: `0xticket${i}` })
+    )
+
+    const message = await buildFundedDigestMessage(childChain, tickets)
+
+    expect(message).toContain('25 unredeemed retryables')
+    expect(message).toContain('0xticket19>')
+    expect(message).not.toContain('0xticket20>')
+    expect(message).toContain('…and 5 more')
+  })
+
+  test('skips USD conversion on custom gas-token chains', async () => {
+    const gasTokenChain = {
+      ...childChain,
+      nativeToken: '0xgastoken',
+    } as ChildNetwork
+
+    const message = await buildFundedDigestMessage(gasTokenChain, [
+      buildTicket(),
+    ])
+
+    expect(message).toContain('*Total unredeemed:* 0.1 gas tokens')
+    expect(message).not.toContain('$')
+  })
+})

--- a/packages/retryable-monitor/__test__/reportFailedRetryables.test.ts
+++ b/packages/retryable-monitor/__test__/reportFailedRetryables.test.ts
@@ -17,8 +17,14 @@ vi.mock('../handlers/slack/postSlackMessage', () => ({
   postSlackMessage: vi.fn(),
 }))
 
+vi.mock('../handlers/fundedTicketDigest', async importOriginal => ({
+  ...(await importOriginal<typeof import('../handlers/fundedTicketDigest')>()),
+  addTicketToFundedDigest: vi.fn(),
+}))
+
 import { reportFailedRetryables } from '../handlers/reportFailedRetryables'
 import { addTicketToZeroValueDigest } from '../handlers/zeroValueTicketDigest'
+import { addTicketToFundedDigest } from '../handlers/fundedTicketDigest'
 
 const nowInSeconds = Math.floor(Date.now() / 1000)
 const DAY_IN_SECONDS = 24 * 60 * 60
@@ -59,6 +65,30 @@ const buildTicket = (
 describe('reportFailedRetryables muting', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+  })
+
+  test('routes funded tickets to the funded buffer, not the zero-value digest', async () => {
+    await reportFailedRetryables(
+      buildTicket({
+        deposit: '100000000000000000',
+      })
+    )
+
+    expect(addTicketToFundedDigest).toHaveBeenCalledOnce()
+    expect(addTicketToZeroValueDigest).not.toHaveBeenCalled()
+  })
+
+  test('muting also applies to funded tickets', async () => {
+    await reportFailedRetryables(
+      buildTicket({
+        deposit: '100000000000000000',
+        status: 'EXPIRED',
+        createdAtTimestamp: String(nowInSeconds - 10 * DAY_IN_SECONDS),
+        timeoutTimestamp: String(nowInSeconds - 3 * DAY_IN_SECONDS),
+      })
+    )
+
+    expect(addTicketToFundedDigest).not.toHaveBeenCalled()
   })
 
   test('mutes CREATION_FAILED tickets older than 2 days', async () => {

--- a/packages/retryable-monitor/__test__/zeroValueTicketDigest.test.ts
+++ b/packages/retryable-monitor/__test__/zeroValueTicketDigest.test.ts
@@ -203,9 +203,19 @@ describe('buildZeroValueDigestMessage', () => {
     const message = buildZeroValueDigestMessage(childChain, tickets)
 
     expect(message).toContain('25 zero-value retryables')
-    expect(message).toContain('0xticket19')
-    expect(message).not.toContain('0xticket20>')
-    expect(message).toContain('…and 5 more')
+    expect(message).toContain('0xticket9>')
+    expect(message).not.toContain('0xticket10>')
+    expect(message).toContain('…and 15 more')
+  })
+
+  test('shortens long ticket ids in the listing while linking the full URL', () => {
+    const longId =
+      '0x81c4e5b5722698ac9c6feb2090683d4ce442b64afd055a7499da5b2cdf51c839'
+    const message = buildZeroValueDigestMessage(childChain, [
+      buildTicket({ childOverrides: { id: longId } }),
+    ])
+
+    expect(message).toContain(`https://child.explorer/tx/${longId}|0x81c4e5…51c839>`)
   })
 })
 

--- a/packages/retryable-monitor/handlers/fundedTicketDigest.ts
+++ b/packages/retryable-monitor/handlers/fundedTicketDigest.ts
@@ -1,4 +1,5 @@
 import { BigNumber, ethers, providers } from 'ethers'
+import { ERC20__factory } from '@arbitrum/sdk/dist/lib/abi/factories/ERC20__factory'
 import { ChildNetwork, getExplorerUrlPrefixes } from 'utils'
 import { OnFailedRetryableFoundParams } from '../core/types'
 import { postSlackMessage } from './slack/postSlackMessage'
@@ -42,12 +43,54 @@ export const addTicketToFundedDigest = (
 const callvalueOf = (ticket: OnFailedRetryableFoundParams): BigNumber =>
   BigNumber.from(ticket.childChainRetryableReport.l2CallValue ?? '0')
 
+interface AmountDisplay {
+  unit: string
+  decimals: number
+  ethPriceUsd?: number
+}
+
+/**
+ * Resolves how callvalue amounts are displayed. Custom gas-token chains
+ * denominate callvalue in the chain's gas token, so its symbol and decimals
+ * are fetched from the parent chain ERC20 (same as formatL2Callvalue);
+ * ETH-gas chains additionally get a USD conversion.
+ */
+const resolveAmountDisplay = async (
+  childChain: ChildNetwork,
+  parentChainProvider?: providers.Provider
+): Promise<AmountDisplay> => {
+  if (!childChain.nativeToken) {
+    try {
+      return { unit: 'ETH', decimals: 18, ethPriceUsd: await getEthPrice() }
+    } catch {
+      // the digest must still post when the price API is down
+      return { unit: 'ETH', decimals: 18 }
+    }
+  }
+
+  if (parentChainProvider) {
+    try {
+      const erc20 = ERC20__factory.connect(
+        childChain.nativeToken,
+        parentChainProvider
+      )
+      const [symbol, decimals] = await Promise.all([
+        erc20.symbol(),
+        erc20.decimals(),
+      ])
+      return { unit: symbol, decimals }
+    } catch {
+      // fall through to the generic label rather than dropping the digest
+    }
+  }
+  return { unit: 'gas tokens', decimals: 18 }
+}
+
 const formatAmount = (
   wei: BigNumber,
-  unit: string,
-  ethPriceUsd?: number
+  { unit, decimals, ethPriceUsd }: AmountDisplay
 ): string => {
-  const exact = parseFloat(ethers.utils.formatEther(wei))
+  const exact = parseFloat(ethers.utils.formatUnits(wei, decimals))
   // 6 decimals is plenty for a summary; the JSON report has exact wei values
   const amount = String(Number(exact.toFixed(6)))
   if (ethPriceUsd === undefined) return `${amount} ${unit}`
@@ -74,21 +117,12 @@ const formatArtifactPointer = (): string => {
 
 export const buildFundedDigestMessage = async (
   childChain: ChildNetwork,
-  tickets: OnFailedRetryableFoundParams[]
+  tickets: OnFailedRetryableFoundParams[],
+  parentChainProvider?: providers.Provider
 ): Promise<string> => {
   const { CHILD_CHAIN_TX_PREFIX } = getExplorerUrlPrefixes(childChain)
 
-  // custom gas-token chains denominate callvalue in the chain's gas token,
-  // for which the cached ETH price would be wrong
-  const unit = childChain.nativeToken ? 'gas tokens' : 'ETH'
-  let ethPriceUsd: number | undefined = undefined
-  if (!childChain.nativeToken) {
-    try {
-      ethPriceUsd = await getEthPrice()
-    } catch {
-      // the digest must still post when the price API is down
-    }
-  }
+  const display = await resolveAmountDisplay(childChain, parentChainProvider)
 
   const totalCallvalue = tickets.reduce(
     (sum, t) => sum.add(callvalueOf(t)),
@@ -132,11 +166,9 @@ export const buildFundedDigestMessage = async (
       const tokenMarker = t.tokenDepositData?.tokenAmount ? ' + tokens' : ''
       return `\n\t\t <${CHILD_CHAIN_TX_PREFIX + report.id}|${shortTicketId(
         report.id
-      )}> — ${ethers.utils.formatEther(
-        callvalueOf(t)
-      )} ${unit}${tokenMarker} — expires ${compactUtcDate(
-        +report.timeoutTimestamp
-      )}`
+      )}> — ${ethers.utils.formatUnits(callvalueOf(t), display.decimals)} ${
+        display.unit
+      }${tokenMarker} — expires ${compactUtcDate(+report.timeoutTimestamp)}`
     })
     .join('')
   const overflowLine =
@@ -150,11 +182,7 @@ export const buildFundedDigestMessage = async (
     } with funds at risk.*` +
     `\n\t Sending a summary instead of individual alerts to avoid spam, since the ticket count exceeds ${MAX_INDIVIDUAL_FUNDED_ALERTS}.` +
     `\n\t *Summary:*` +
-    `\n\t *Total unredeemed:* ${formatAmount(
-      totalCallvalue,
-      unit,
-      ethPriceUsd
-    )}${
+    `\n\t *Total unredeemed:* ${formatAmount(totalCallvalue, display)}${
       tokenDepositCount > 0
         ? ` (+${tokenDepositCount} ticket${
             tokenDepositCount === 1 ? '' : 's'
@@ -163,9 +191,8 @@ export const buildFundedDigestMessage = async (
     }` +
     `\n\t *Average per ticket:* ${formatAmount(
       averageCallvalue,
-      unit,
-      ethPriceUsd
-    )} | *Largest:* ${formatAmount(largestCallvalue, unit, ethPriceUsd)}` +
+      display
+    )} | *Largest:* ${formatAmount(largestCallvalue, display)}` +
     `\n\t *By status:* ${statusCounts
       .map(([status, count]) => `${status}: ${count}`)
       .join(', ')}` +
@@ -194,23 +221,27 @@ export const postFundedTicketAlerts = async (childChain: ChildNetwork) => {
 
   if (!tickets || tickets.length === 0) return
 
-  if (tickets.length > MAX_INDIVIDUAL_FUNDED_ALERTS) {
-    try {
-      await postSlackMessage({
-        message: await buildFundedDigestMessage(childChain, tickets),
-      })
-    } catch (e) {
-      console.log('Could not send funded-ticket digest slack message', e)
-    }
-    return
-  }
-
   const childChainProvider = new providers.JsonRpcProvider(
     String(childChain.orbitRpcUrl)
   )
   const parentChainProvider = new providers.JsonRpcProvider(
     String(childChain.parentRpcUrl)
   )
+
+  if (tickets.length > MAX_INDIVIDUAL_FUNDED_ALERTS) {
+    try {
+      await postSlackMessage({
+        message: await buildFundedDigestMessage(
+          childChain,
+          tickets,
+          parentChainProvider
+        ),
+      })
+    } catch (e) {
+      console.log('Could not send funded-ticket digest slack message', e)
+    }
+    return
+  }
 
   for (const ticket of tickets) {
     try {

--- a/packages/retryable-monitor/handlers/fundedTicketDigest.ts
+++ b/packages/retryable-monitor/handlers/fundedTicketDigest.ts
@@ -7,14 +7,26 @@ import {
   getEthPrice,
 } from './slack/slackMessageFormattingUtils'
 import { generateFailedRetryableSlackMessage } from './slack/slackMessageGenerator'
-import { countBy, STATUS_LABELS } from './zeroValueTicketDigest'
+import { countBy, STATUS_LABELS, shortTicketId } from './zeroValueTicketDigest'
 
 // up to this many funded tickets per chain per run get the full per-ticket
 // alert; beyond that the run posts a single digest instead, so a burst of
 // deposits (e.g. a misconfigured depositor bot) doesn't flood the channel
 export const MAX_INDIVIDUAL_FUNDED_ALERTS = 5
-const MAX_TICKETS_LISTED = 20
+// Slack splits messages around ~4k characters (URLs included), so the cap
+// keeps the digest a single message; the full list is in the JSON report
+const MAX_TICKETS_LISTED = 10
 const MAX_SENDERS_LISTED = 5
+
+const MONTHS = 'Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec'.split(' ')
+
+const compactUtcDate = (tsSeconds: number): string => {
+  const d = new Date(tsSeconds * 1000)
+  const pad = (n: number) => String(n).padStart(2, '0')
+  return `${pad(d.getUTCDate())} ${MONTHS[d.getUTCMonth()]} ${pad(
+    d.getUTCHours()
+  )}:${pad(d.getUTCMinutes())} UTC`
+}
 
 const ticketsByChainId = new Map<number, OnFailedRetryableFoundParams[]>()
 
@@ -35,9 +47,11 @@ const formatAmount = (
   unit: string,
   ethPriceUsd?: number
 ): string => {
-  const amount = ethers.utils.formatEther(wei)
+  const exact = parseFloat(ethers.utils.formatEther(wei))
+  // 6 decimals is plenty for a summary; the JSON report has exact wei values
+  const amount = String(Number(exact.toFixed(6)))
   if (ethPriceUsd === undefined) return `${amount} ${unit}`
-  const usd = parseFloat(amount) * ethPriceUsd
+  const usd = exact * ethPriceUsd
   return `${amount} ${unit} (~$${usd.toFixed(2)})`
 }
 
@@ -116,9 +130,11 @@ export const buildFundedDigestMessage = async (
     .map(t => {
       const report = t.childChainRetryableReport
       const tokenMarker = t.tokenDepositData?.tokenAmount ? ' + tokens' : ''
-      return `\n\t\t <${CHILD_CHAIN_TX_PREFIX + report.id}|${
+      return `\n\t\t <${CHILD_CHAIN_TX_PREFIX + report.id}|${shortTicketId(
         report.id
-      }> — ${ethers.utils.formatEther(callvalueOf(t))} ${unit}${tokenMarker} — expires ${timestampToDate(
+      )}> — ${ethers.utils.formatEther(
+        callvalueOf(t)
+      )} ${unit}${tokenMarker} — expires ${compactUtcDate(
         +report.timeoutTimestamp
       )}`
     })

--- a/packages/retryable-monitor/handlers/fundedTicketDigest.ts
+++ b/packages/retryable-monitor/handlers/fundedTicketDigest.ts
@@ -1,0 +1,214 @@
+import { BigNumber, ethers, providers } from 'ethers'
+import { ChildNetwork, getExplorerUrlPrefixes } from 'utils'
+import { OnFailedRetryableFoundParams } from '../core/types'
+import { postSlackMessage } from './slack/postSlackMessage'
+import {
+  timestampToDate,
+  getEthPrice,
+} from './slack/slackMessageFormattingUtils'
+import { generateFailedRetryableSlackMessage } from './slack/slackMessageGenerator'
+import { countBy, STATUS_LABELS } from './zeroValueTicketDigest'
+
+// up to this many funded tickets per chain per run get the full per-ticket
+// alert; beyond that the run posts a single digest instead, so a burst of
+// deposits (e.g. a misconfigured depositor bot) doesn't flood the channel
+export const MAX_INDIVIDUAL_FUNDED_ALERTS = 5
+const MAX_TICKETS_LISTED = 20
+const MAX_SENDERS_LISTED = 5
+
+const ticketsByChainId = new Map<number, OnFailedRetryableFoundParams[]>()
+
+export const addTicketToFundedDigest = (
+  ticket: OnFailedRetryableFoundParams
+) => {
+  const { chainId } = ticket.childChain
+  const tickets = ticketsByChainId.get(chainId) ?? []
+  tickets.push(ticket)
+  ticketsByChainId.set(chainId, tickets)
+}
+
+const callvalueOf = (ticket: OnFailedRetryableFoundParams): BigNumber =>
+  BigNumber.from(ticket.childChainRetryableReport.l2CallValue ?? '0')
+
+const formatAmount = (
+  wei: BigNumber,
+  unit: string,
+  ethPriceUsd?: number
+): string => {
+  const amount = ethers.utils.formatEther(wei)
+  if (ethPriceUsd === undefined) return `${amount} ${unit}`
+  const usd = parseFloat(amount) * ethPriceUsd
+  return `${amount} ${unit} (~$${usd.toFixed(2)})`
+}
+
+const formatTimeLeft = (untilSeconds: number): string => {
+  const secondsLeft = untilSeconds - Math.floor(Date.now() / 1000)
+  if (secondsLeft <= 0) return 'already passed'
+  const days = Math.floor(secondsLeft / (24 * 60 * 60))
+  const hours = Math.floor((secondsLeft % (24 * 60 * 60)) / (60 * 60))
+  return `in ${days}d ${hours}h`
+}
+
+const formatArtifactPointer = (): string => {
+  const repository = process.env.GITHUB_REPOSITORY
+  const runId = process.env.GITHUB_RUN_ID
+  if (repository && runId) {
+    return `\n\t ⚠️ Please check the *retryable-run-report.json* artifact on <https://github.com/${repository}/actions/runs/${runId}|this run> urgently for full per-ticket redemption details.`
+  }
+  return `\n\t ⚠️ Please check *retryable-run-report.json* in the run's working directory urgently for full per-ticket redemption details.`
+}
+
+export const buildFundedDigestMessage = async (
+  childChain: ChildNetwork,
+  tickets: OnFailedRetryableFoundParams[]
+): Promise<string> => {
+  const { CHILD_CHAIN_TX_PREFIX } = getExplorerUrlPrefixes(childChain)
+
+  // custom gas-token chains denominate callvalue in the chain's gas token,
+  // for which the cached ETH price would be wrong
+  const unit = childChain.nativeToken ? 'gas tokens' : 'ETH'
+  let ethPriceUsd: number | undefined = undefined
+  if (!childChain.nativeToken) {
+    try {
+      ethPriceUsd = await getEthPrice()
+    } catch {
+      // the digest must still post when the price API is down
+    }
+  }
+
+  const totalCallvalue = tickets.reduce(
+    (sum, t) => sum.add(callvalueOf(t)),
+    BigNumber.from(0)
+  )
+  const averageCallvalue = totalCallvalue.div(tickets.length)
+  const largestCallvalue = tickets.reduce(
+    (max, t) => (callvalueOf(t).gt(max) ? callvalueOf(t) : max),
+    BigNumber.from(0)
+  )
+  const tokenDepositCount = tickets.filter(t =>
+    Boolean(t.tokenDepositData?.tokenAmount)
+  ).length
+
+  const statusCounts = countBy(
+    tickets,
+    t =>
+      STATUS_LABELS[t.childChainRetryableReport.status] ??
+      t.childChainRetryableReport.status
+  )
+  const senderCounts = countBy(tickets, t => t.parentChainRetryableReport.sender)
+  const listedSenders = senderCounts.slice(0, MAX_SENDERS_LISTED)
+  const senderOverflow =
+    senderCounts.length > MAX_SENDERS_LISTED
+      ? `, …and ${senderCounts.length - MAX_SENDERS_LISTED} more senders`
+      : ''
+  const distinctDestinations = new Set(
+    tickets.map(t => t.childChainRetryableReport.retryTo)
+  ).size
+
+  const timeouts = tickets.map(t =>
+    Number(t.childChainRetryableReport.timeoutTimestamp)
+  )
+  const earliestExpiry = Math.min(...timeouts)
+  const latestExpiry = Math.max(...timeouts)
+
+  const ticketLines = tickets
+    .slice(0, MAX_TICKETS_LISTED)
+    .map(t => {
+      const report = t.childChainRetryableReport
+      const tokenMarker = t.tokenDepositData?.tokenAmount ? ' + tokens' : ''
+      return `\n\t\t <${CHILD_CHAIN_TX_PREFIX + report.id}|${
+        report.id
+      }> — ${ethers.utils.formatEther(callvalueOf(t))} ${unit}${tokenMarker} — expires ${timestampToDate(
+        +report.timeoutTimestamp
+      )}`
+    })
+    .join('')
+  const overflowLine =
+    tickets.length > MAX_TICKETS_LISTED
+      ? `\n\t\t …and ${tickets.length - MAX_TICKETS_LISTED} more`
+      : ''
+
+  return (
+    `🚨 *[${childChain.name}] URGENT: ${tickets.length} unredeemed retryable${
+      tickets.length === 1 ? '' : 's'
+    } with funds at risk.*` +
+    `\n\t Sending a summary instead of individual alerts to avoid spam, since the ticket count exceeds ${MAX_INDIVIDUAL_FUNDED_ALERTS}.` +
+    `\n\t *Summary:*` +
+    `\n\t *Total unredeemed:* ${formatAmount(
+      totalCallvalue,
+      unit,
+      ethPriceUsd
+    )}${
+      tokenDepositCount > 0
+        ? ` (+${tokenDepositCount} ticket${
+            tokenDepositCount === 1 ? '' : 's'
+          } with token deposits)`
+        : ''
+    }` +
+    `\n\t *Average per ticket:* ${formatAmount(
+      averageCallvalue,
+      unit,
+      ethPriceUsd
+    )} | *Largest:* ${formatAmount(largestCallvalue, unit, ethPriceUsd)}` +
+    `\n\t *By status:* ${statusCounts
+      .map(([status, count]) => `${status}: ${count}`)
+      .join(', ')}` +
+    `\n\t *By sender:* ${listedSenders
+      .map(([sender, count]) => `${sender}: ${count}`)
+      .join(', ')}${senderOverflow} | *Distinct destinations:* ${distinctDestinations}` +
+    `\n\t *Expiry window:* earliest ${timestampToDate(
+      earliestExpiry
+    )} (${formatTimeLeft(earliestExpiry)}) → latest ${timestampToDate(
+      latestExpiry
+    )} (${formatTimeLeft(latestExpiry)})` +
+    `\n\t *Tickets:*${ticketLines}${overflowLine}` +
+    formatArtifactPointer() +
+    '\n================================================================='
+  )
+}
+
+/**
+ * Flushes the funded tickets accumulated for a chain during the run. Up to
+ * MAX_INDIVIDUAL_FUNDED_ALERTS tickets get the usual detailed per-ticket
+ * alert; a larger batch is rolled into a single digest message.
+ */
+export const postFundedTicketAlerts = async (childChain: ChildNetwork) => {
+  const tickets = ticketsByChainId.get(childChain.chainId)
+  ticketsByChainId.delete(childChain.chainId)
+
+  if (!tickets || tickets.length === 0) return
+
+  if (tickets.length > MAX_INDIVIDUAL_FUNDED_ALERTS) {
+    try {
+      await postSlackMessage({
+        message: await buildFundedDigestMessage(childChain, tickets),
+      })
+    } catch (e) {
+      console.log('Could not send funded-ticket digest slack message', e)
+    }
+    return
+  }
+
+  const childChainProvider = new providers.JsonRpcProvider(
+    String(childChain.orbitRpcUrl)
+  )
+  const parentChainProvider = new providers.JsonRpcProvider(
+    String(childChain.parentRpcUrl)
+  )
+
+  for (const ticket of tickets) {
+    try {
+      const message = await generateFailedRetryableSlackMessage({
+        parentChainRetryableReport: ticket.parentChainRetryableReport,
+        childChainRetryableReport: ticket.childChainRetryableReport,
+        tokenDepositData: ticket.tokenDepositData,
+        childChain,
+        parentChainProvider,
+        childChainProvider,
+      })
+      await postSlackMessage({ message })
+    } catch (e) {
+      console.log('Could not send slack message', e)
+    }
+  }
+}

--- a/packages/retryable-monitor/handlers/reportFailedRetryables.ts
+++ b/packages/retryable-monitor/handlers/reportFailedRetryables.ts
@@ -1,16 +1,14 @@
-import { providers } from 'ethers'
 import { ChildNetwork } from 'utils'
 import {
   ChildChainTicketReport,
   ParentChainTicketReport,
   TokenDepositData,
 } from '../core/types'
-import { postSlackMessage } from './slack/postSlackMessage'
-import { generateFailedRetryableSlackMessage } from './slack/slackMessageGenerator'
 import {
   addTicketToZeroValueDigest,
   isZeroValueTicket,
 } from './zeroValueTicketDigest'
+import { addTicketToFundedDigest } from './fundedTicketDigest'
 
 export const reportFailedRetryables = async ({
   parentChainRetryableReport,
@@ -71,26 +69,13 @@ export const reportFailedRetryables = async ({
     return
   }
 
-  const childChainProvider = new providers.JsonRpcProvider(
-    String(childChain.orbitRpcUrl)
-  )
-
-  const parentChainProvider = new providers.JsonRpcProvider(
-    String(childChain.parentRpcUrl)
-  )
-
-  try {
-    const reportStr = await generateFailedRetryableSlackMessage({
-      parentChainRetryableReport,
-      childChainRetryableReport,
-      tokenDepositData,
-      childChain,
-      parentChainProvider,
-      childChainProvider,
-    })
-
-    postSlackMessage({ message: reportStr })
-  } catch (e) {
-    console.log('Could not send slack message', e)
-  }
+  // funded tickets are buffered too: small batches are posted as the usual
+  // detailed per-ticket alerts once the chain's run completes, large bursts
+  // are rolled into a single digest (see postFundedTicketAlerts)
+  addTicketToFundedDigest({
+    parentChainRetryableReport,
+    childChainRetryableReport,
+    tokenDepositData,
+    childChain,
+  })
 }

--- a/packages/retryable-monitor/handlers/zeroValueTicketDigest.ts
+++ b/packages/retryable-monitor/handlers/zeroValueTicketDigest.ts
@@ -57,14 +57,14 @@ export const addTicketToZeroValueDigest = (
   ticketsByChainId.set(chainId, tickets)
 }
 
-const STATUS_LABELS: Record<string, string> = {
+export const STATUS_LABELS: Record<string, string> = {
   FUNDS_DEPOSITED_ON_CHILD: 'created but not redeemed',
   CREATION_FAILED: 'creation failed',
   EXPIRED: 'expired',
   NOT_YET_CREATED: 'not yet scheduled',
 }
 
-const countBy = (
+export const countBy = (
   tickets: OnFailedRetryableFoundParams[],
   getKey: (ticket: OnFailedRetryableFoundParams) => string
 ): [string, number][] => {

--- a/packages/retryable-monitor/handlers/zeroValueTicketDigest.ts
+++ b/packages/retryable-monitor/handlers/zeroValueTicketDigest.ts
@@ -5,9 +5,15 @@ import { postSlackMessage } from './slack/postSlackMessage'
 import { timestampToDate } from './slack/slackMessageFormattingUtils'
 
 // cap the per-ticket and per-sender lines in the digest; the full list always
-// lands in the run's JSON report
-const MAX_TICKETS_LISTED = 20
+// lands in the run's JSON report. Slack splits messages around ~4k characters
+// (URLs included), so the cap keeps the digest a single message.
+const MAX_TICKETS_LISTED = 10
 const MAX_SENDERS_LISTED = 5
+
+// slack renders <url|label>; a shortened label keeps the digest compact while
+// the link still leads to the full ticket
+export const shortTicketId = (id: string): string =>
+  id.length <= 18 ? id : `${id.slice(0, 8)}…${id.slice(-6)}`
 
 const isZeroAmount = (amount?: string) => {
   if (!amount) return true
@@ -118,7 +124,9 @@ export const buildZeroValueDigestMessage = (
         report.status === 'CREATION_FAILED'
           ? 'never created, no expiry'
           : `expires ${timestampToDate(+report.timeoutTimestamp)}`
-      return `\n\t\t <${CHILD_CHAIN_TX_PREFIX + report.id}|${report.id}> — ${expiry}`
+      return `\n\t\t <${CHILD_CHAIN_TX_PREFIX + report.id}|${shortTicketId(
+        report.id
+      )}> — ${expiry}`
     })
     .join('')
   const overflowLine =

--- a/packages/retryable-monitor/index.ts
+++ b/packages/retryable-monitor/index.ts
@@ -18,6 +18,7 @@ import { fetchNotionRetryables } from './handlers/notion/fetchedNotionRetryables
 import { handleFailedRetryablesFound } from './handlers/handleFailedRetryablesFound'
 import { handleRedeemedRetryablesFound } from './handlers/handleRedeemedRetryablesFound'
 import { postZeroValueDigest } from './handlers/zeroValueTicketDigest'
+import { postFundedTicketAlerts } from './handlers/fundedTicketDigest'
 import { writeRunReport } from './handlers/runReport'
 
 // Path for the log file
@@ -191,11 +192,12 @@ const processOrbitChainsConcurrently = async () => {
       }
       console.error(errorStr)
     } finally {
-      // zero-value tickets accumulate while the chain is checked; flush the
-      // per-chain digest even when processing errored mid-run so a partial
-      // digest is posted instead of silently dropped (no-ops when nothing
-      // was accumulated)
+      // zero-value and funded tickets accumulate while the chain is checked;
+      // flush both per-chain buffers even when processing errored mid-run so
+      // partial results are posted instead of silently dropped (no-ops when
+      // nothing was accumulated)
       await postZeroValueDigest(childChain)
+      await postFundedTicketAlerts(childChain)
     }
   })
 


### PR DESCRIPTION
## Problem

The 31 Jul run posted ~55 individual alerts for Robinhood Chain: a depositor bot created a burst of funded tickets whose auto-redeems all failed. Every alert was legitimate, but the volume buries the signal.

## Change

Funded tickets are buffered per chain and flushed when the chain's scan completes:

- **5 or fewer** → the usual detailed per-ticket alerts, unchanged.
- **More than 5** → one summary digest: total / average / largest unredeemed value (ETH + USD), counts by status and sender, distinct destinations, expiry window with countdowns, up to 10 shortened ticket links, and an urgent pointer to the run's `retryable-run-report.json` artifact for full redemption details.

Ticket link labels are shortened (`0x81c4e5…51c839`) and the listing capped at 10 in both this and the zero-value digest, keeping the raw payload well under Slack's ~4k message-split limit.

## Testing

- 58 package tests passing (12 cover the digest: threshold routing, flush semantics, summary math, expiry countdowns, artifact link, short labels, sub-4k payload with 55 realistic ids).
- Verified against real data: ran the monitor over the 30 Jul L1 block window — ~138 retryables scanned, 19 still unredeemed, exactly one Slack message produced instead of 19.