### PR TITLE
fix(retryable-monitor): make auto-redemption work

### DIFF
--- a/packages/retryable-monitor/__test__/alertUntriagedRetryables.test.ts
+++ b/packages/retryable-monitor/__test__/alertUntriagedRetryables.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+const databasesQuery = vi.fn()
+const pagesUpdate = vi.fn()
+
+vi.mock('../handlers/notion/createNotionClient', () => ({
+  notionClient: {
+    databases: { query: (...args: unknown[]) => databasesQuery(...args) },
+    pages: { update: (...args: unknown[]) => pagesUpdate(...args) },
+  },
+  databaseId: 'test-db',
+}))
+
+vi.mock('../core/redeemRetryable', () => ({ redeemRetryable: vi.fn() }))
+
+vi.mock('../handlers/slack/postSlackMessage', () => ({
+  postSlackMessage: vi.fn(),
+}))
+
+import {
+  alertUntriagedNotionRetryables,
+  extractTxHash,
+} from '../handlers/notion/alertUntriagedRetraybles'
+import { redeemRetryable } from '../core/redeemRetryable'
+
+const PARENT_TX_HASH =
+  '0xe60d848b8fae81b103135825c30c2ca169170100cad7fbdf3e73d062e3fc90d6'
+
+const CHAINS = [{ chainId: 42161 }] as any
+
+const buildPage = (hoursUntilExpiry: number) => ({
+  id: 'page-1',
+  properties: {
+    ChainID: { number: 42161 },
+    Status: { select: { name: 'Pending' } },
+    Decision: { select: { name: 'Should Redeem' } },
+    ParentTx: {
+      rich_text: [
+        { text: { content: `https://etherscan.io/tx/${PARENT_TX_HASH}` } },
+      ],
+    },
+    ChildTx: { title: [{ text: { content: 'https://arbiscan.io/tx/0xabc' } }] },
+    timeoutTimestamp: {
+      date: {
+        start: new Date(
+          Date.now() + hoursUntilExpiry * 60 * 60 * 1000
+        ).toISOString(),
+      },
+    },
+  },
+})
+
+describe('extractTxHash', () => {
+  test('pulls the hash out of an explorer URL', () => {
+    expect(extractTxHash(`https://etherscan.io/tx/${PARENT_TX_HASH}`)).toBe(
+      PARENT_TX_HASH
+    )
+  })
+
+  test('passes a raw hash through', () => {
+    expect(extractTxHash(PARENT_TX_HASH)).toBe(PARENT_TX_HASH)
+  })
+
+  test('returns null when there is no hash', () => {
+    expect(extractTxHash('(unknown)')).toBeNull()
+    expect(extractTxHash(undefined)).toBeNull()
+  })
+})
+
+describe('alertUntriagedNotionRetryables', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    databasesQuery.mockResolvedValue({ results: [buildPage(48)] })
+  })
+
+  test('redeems with the raw hash, not the explorer URL', async () => {
+    await alertUntriagedNotionRetryables(CHAINS, true)
+
+    expect(redeemRetryable).toHaveBeenCalledWith(PARENT_TX_HASH)
+    expect(pagesUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        properties: {
+          'Bot Redemption Status': { select: { name: 'Bot Success' } },
+        },
+      })
+    )
+  })
+
+  test('marks the page as failed when the redeem throws', async () => {
+    vi.mocked(redeemRetryable).mockRejectedValueOnce(new Error('boom'))
+
+    await alertUntriagedNotionRetryables(CHAINS, true)
+
+    expect(pagesUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        properties: {
+          'Bot Redemption Status': { select: { name: 'Bot Failed' } },
+        },
+      })
+    )
+  })
+
+  test('does not redeem when auto-redeem is disabled', async () => {
+    await alertUntriagedNotionRetryables(CHAINS, false)
+
+    expect(redeemRetryable).not.toHaveBeenCalled()
+    expect(pagesUpdate).not.toHaveBeenCalled()
+  })
+})

--- a/packages/retryable-monitor/__test__/alertUntriagedRetryables.test.ts
+++ b/packages/retryable-monitor/__test__/alertUntriagedRetryables.test.ts
@@ -25,6 +25,8 @@ import { redeemRetryable } from '../core/redeemRetryable'
 
 const PARENT_TX_HASH =
   '0xe60d848b8fae81b103135825c30c2ca169170100cad7fbdf3e73d062e3fc90d6'
+const CHILD_TX_HASH =
+  '0xa0922360dad7e9d29b6aecd543f323cb9524e30edd2d1a45d758fcd8fa786a9e'
 
 const CHAINS = [{ chainId: 42161 }] as any
 
@@ -39,7 +41,15 @@ const buildPage = (hoursUntilExpiry: number) => ({
         { text: { content: `https://etherscan.io/tx/${PARENT_TX_HASH}` } },
       ],
     },
-    ChildTx: { title: [{ text: { content: 'https://arbiscan.io/tx/0xabc' } }] },
+    ChildTx: {
+      title: [
+        {
+          text: {
+            content: `https://robinhoodchain.blockscout.com/tx/${CHILD_TX_HASH}`,
+          },
+        },
+      ],
+    },
     timeoutTimestamp: {
       date: {
         start: new Date(
@@ -76,7 +86,10 @@ describe('alertUntriagedNotionRetryables', () => {
   test('redeems with the raw hash, not the explorer URL', async () => {
     await alertUntriagedNotionRetryables(CHAINS, true)
 
-    expect(redeemRetryable).toHaveBeenCalledWith(PARENT_TX_HASH)
+    expect(redeemRetryable).toHaveBeenCalledWith(
+      PARENT_TX_HASH,
+      expect.objectContaining({ retryableCreationId: CHILD_TX_HASH })
+    )
     expect(pagesUpdate).toHaveBeenCalledWith(
       expect.objectContaining({
         properties: {
@@ -97,6 +110,15 @@ describe('alertUntriagedNotionRetryables', () => {
           'Bot Redemption Status': { select: { name: 'Bot Failed' } },
         },
       })
+    )
+  })
+
+  test('forwards the config path it was run with', async () => {
+    await alertUntriagedNotionRetryables(CHAINS, true, '../../rh.config.json')
+
+    expect(redeemRetryable).toHaveBeenCalledWith(
+      PARENT_TX_HASH,
+      expect.objectContaining({ configPath: '../../rh.config.json' })
     )
   })
 

--- a/packages/retryable-monitor/__test__/alertUntriagedRetryables.test.ts
+++ b/packages/retryable-monitor/__test__/alertUntriagedRetryables.test.ts
@@ -30,7 +30,10 @@ const CHILD_TX_HASH =
 
 const CHAINS = [{ chainId: 42161 }] as any
 
-const buildPage = (hoursUntilExpiry: number) => ({
+const buildPage = (
+  hoursUntilExpiry: number,
+  childTx = `https://robinhoodchain.blockscout.com/tx/${CHILD_TX_HASH}`
+) => ({
   id: 'page-1',
   properties: {
     ChainID: { number: 42161 },
@@ -41,15 +44,7 @@ const buildPage = (hoursUntilExpiry: number) => ({
         { text: { content: `https://etherscan.io/tx/${PARENT_TX_HASH}` } },
       ],
     },
-    ChildTx: {
-      title: [
-        {
-          text: {
-            content: `https://robinhoodchain.blockscout.com/tx/${CHILD_TX_HASH}`,
-          },
-        },
-      ],
-    },
+    ChildTx: { title: [{ text: { content: childTx } }] },
     timeoutTimestamp: {
       date: {
         start: new Date(
@@ -120,6 +115,15 @@ describe('alertUntriagedNotionRetryables', () => {
       PARENT_TX_HASH,
       expect.objectContaining({ configPath: '../../rh.config.json' })
     )
+  })
+
+  test('skips rather than redeeming a sibling ticket when ChildTx is unusable', async () => {
+    databasesQuery.mockResolvedValue({ results: [buildPage(48, '(unknown)')] })
+
+    await alertUntriagedNotionRetryables(CHAINS, true)
+
+    expect(redeemRetryable).not.toHaveBeenCalled()
+    expect(pagesUpdate).not.toHaveBeenCalled()
   })
 
   test('does not redeem when auto-redeem is disabled', async () => {

--- a/packages/retryable-monitor/core/redeemRetryable.ts
+++ b/packages/retryable-monitor/core/redeemRetryable.ts
@@ -9,9 +9,11 @@ import dotenv from 'dotenv'
 dotenv.config()
 
 export const redeemRetryable = async (
-  parentTxHash: string
+  parentTxHash: string,
+  options: { configPath?: string; retryableCreationId?: string } = {}
 ): Promise<string> => {
-  const config = getConfig({ configPath: DEFAULT_CONFIG_PATH })
+  const { configPath = DEFAULT_CONFIG_PATH, retryableCreationId } = options
+  const config = getConfig({ configPath })
 
   const pk = process.env.RETRYABLE_MONITORING_PRIVATE_KEY
   if (!pk) {
@@ -43,8 +45,17 @@ export const redeemRetryable = async (
       const messages = await parentReceipt.getParentToChildMessages(wallet)
       if (!messages || messages.length === 0) continue // no L1->L2 messages associated; try next chain
 
-      // If multiple, redeem the first (adjust selection logic if needed)
-      const message = messages[0]
+      // a parent tx can create several tickets; pick the requested one so we
+      // never redeem a sibling ticket, falling back to the first when the
+      // caller has no specific ticket in mind
+      const message = retryableCreationId
+        ? messages.find(
+            m =>
+              m.retryableCreationId.toLowerCase() ===
+              retryableCreationId.toLowerCase()
+          )
+        : messages[0]
+      if (!message) continue
 
       // 3) If already redeemed, return its tx hash instead of throwing
       const already = await message.getSuccessfulRedeem().catch(() => null)

--- a/packages/retryable-monitor/handlers/notion/alertUntriagedRetraybles.ts
+++ b/packages/retryable-monitor/handlers/notion/alertUntriagedRetraybles.ts
@@ -111,9 +111,12 @@ export const alertUntriagedNotionRetryables = async (
         if (!enableAutoRedeem) continue
 
         const parentTxHash = extractTxHash(parentTx)
-        if (!parentTxHash) {
+        const retryableCreationId = extractTxHash(retryableUrl)
+        // never fall back to redeeming an arbitrary ticket: without the
+        // row's own ticket id we could redeem a sibling from the same parent tx
+        if (!parentTxHash || !retryableCreationId) {
           console.error(
-            `[notion] no parent tx hash found in "${parentTx}", skipping auto-redeem`
+            `[notion] skipping auto-redeem, could not read tx hashes (parent: "${parentTx}", ticket: "${retryableUrl}")`
           )
           continue
         }
@@ -121,7 +124,7 @@ export const alertUntriagedNotionRetryables = async (
         try {
           await redeemRetryable(parentTxHash, {
             configPath,
-            retryableCreationId: extractTxHash(retryableUrl) ?? undefined,
+            retryableCreationId,
           })
           await notionClient.pages.update({
             page_id: page.id,

--- a/packages/retryable-monitor/handlers/notion/alertUntriagedRetraybles.ts
+++ b/packages/retryable-monitor/handlers/notion/alertUntriagedRetraybles.ts
@@ -1,7 +1,7 @@
 import { notionClient, databaseId } from './createNotionClient'
 import { postSlackMessage } from '../slack/postSlackMessage'
 import { redeemRetryable } from '../../core/redeemRetryable'
-import type { ChildNetwork } from 'utils'
+import { DEFAULT_CONFIG_PATH, type ChildNetwork } from 'utils'
 
 const formatDate = (iso: string | undefined) => {
   if (!iso) return '(unknown)'
@@ -32,7 +32,8 @@ const isNearExpiry = (iso: string | undefined, hours = 24) => {
 
 export const alertUntriagedNotionRetryables = async (
   childChains: ChildNetwork[] = [],
-  enableAutoRedeem = false
+  enableAutoRedeem = false,
+  configPath: string = DEFAULT_CONFIG_PATH
 ) => {
   const allowedChainIds = childChains.map(c => c.chainId)
   const response = await notionClient.databases.query({
@@ -118,7 +119,10 @@ export const alertUntriagedNotionRetryables = async (
         }
 
         try {
-          await redeemRetryable(parentTxHash)
+          await redeemRetryable(parentTxHash, {
+            configPath,
+            retryableCreationId: extractTxHash(retryableUrl) ?? undefined,
+          })
           await notionClient.pages.update({
             page_id: page.id,
             properties: {

--- a/packages/retryable-monitor/handlers/notion/alertUntriagedRetraybles.ts
+++ b/packages/retryable-monitor/handlers/notion/alertUntriagedRetraybles.ts
@@ -18,6 +18,10 @@ const formatDate = (iso: string | undefined) => {
   }).format(date)
 }
 
+// Notion's ParentTx property stores the explorer URL, not the raw hash
+export const extractTxHash = (value: string | undefined) =>
+  value?.match(/0x[a-fA-F0-9]{64}/)?.[0] ?? null
+
 const isNearExpiry = (iso: string | undefined, hours = 24) => {
   if (!iso) return false
   const expiry = new Date(iso).getTime()
@@ -28,7 +32,7 @@ const isNearExpiry = (iso: string | undefined, hours = 24) => {
 
 export const alertUntriagedNotionRetryables = async (
   childChains: ChildNetwork[] = [],
-  enableAutoRedeem = false // controls >96h silent redemption
+  enableAutoRedeem = false
 ) => {
   const allowedChainIds = childChains.map(c => c.chainId)
   const response = await notionClient.databases.query({
@@ -103,8 +107,18 @@ export const alertUntriagedNotionRetryables = async (
       if (under24HoursLeftToExpire) {
         message = `🚨 Retryable marked for redemption and nearing expiry:\n• Retryable: ${retryableUrl}\n• Timeout: ${timeoutStr}\n• Parent Tx: ${parentTx}\n• Total value deposited: ${deposit}\n→ Check why it hasn't been executed.`
       } else if (hoursLeft <= 96) {
+        if (!enableAutoRedeem) continue
+
+        const parentTxHash = extractTxHash(parentTx)
+        if (!parentTxHash) {
+          console.error(
+            `[notion] no parent tx hash found in "${parentTx}", skipping auto-redeem`
+          )
+          continue
+        }
+
         try {
-          await redeemRetryable(parentTx)
+          await redeemRetryable(parentTxHash)
           await notionClient.pages.update({
             page_id: page.id,
             properties: {
@@ -113,7 +127,8 @@ export const alertUntriagedNotionRetryables = async (
               },
             },
           })
-        } catch {
+        } catch (err) {
+          console.error(`[notion] auto-redeem failed for ${parentTxHash}:`, err)
           await notionClient.pages.update({
             page_id: page.id,
             properties: {

--- a/packages/retryable-monitor/index.ts
+++ b/packages/retryable-monitor/index.ts
@@ -113,7 +113,8 @@ const processChildChain = async (
       setInterval(async () => {
         await alertUntriagedNotionRetryables(
           config.childChains,
-          options.autoRedeem
+          options.autoRedeem,
+          options.configPath
         )
       }, 1000 * 60 * 60) // Run every hour
     }
@@ -206,7 +207,11 @@ const processOrbitChainsConcurrently = async () => {
 
   // once we process all the chains go through the Notion database once to alert on any `Unresolved` tickets found
   if (options.writeToNotion) {
-    await alertUntriagedNotionRetryables(config.childChains, options.autoRedeem)
+    await alertUntriagedNotionRetryables(
+      config.childChains,
+      options.autoRedeem,
+      options.configPath
+    )
   }
 
   // dump every failed retryable found in this run to a JSON file which CI

--- a/packages/retryable-monitor/index.ts
+++ b/packages/retryable-monitor/index.ts
@@ -106,18 +106,6 @@ const processChildChain = async (
         await handleRedeemedRetryablesFound(ticket, writeToNotion)
       },
     })
-
-    // todo: get closure on this - will it even be called
-    if (writeToNotion) {
-      console.log('Activating continuous sweep of Notion database...')
-      setInterval(async () => {
-        await alertUntriagedNotionRetryables(
-          config.childChains,
-          options.autoRedeem,
-          options.configPath
-        )
-      }, 1000 * 60 * 60) // Run every hour
-    }
   } else {
     console.log('Activating one-off check for retryables...')
     const retryablesFound = await checkRetryablesOneOff({
@@ -212,6 +200,19 @@ const processOrbitChainsConcurrently = async () => {
       options.autoRedeem,
       options.configPath
     )
+
+    // one sweep covering every chain, never one sweep per chain: concurrent
+    // sweeps read the same rows and would each submit a redemption for them
+    if (options.continuous) {
+      console.log('Activating continuous sweep of Notion database...')
+      setInterval(async () => {
+        await alertUntriagedNotionRetryables(
+          config.childChains,
+          options.autoRedeem,
+          options.configPath
+        )
+      }, 1000 * 60 * 60) // Run every hour
+    }
   }
 
   // dump every failed retryable found in this run to a JSON file which CI


### PR DESCRIPTION
Auto-redemption has never succeeded (17 `Bot Failed`, 0 `Bot Success` in the triage DB). Fixes:

- redeem the parent tx hash instead of the explorer URL Notion stores in `ParentTx` (ethers threw `invalid hash` every time)
- pass the run's `--configPath` to the redeemer instead of hardcoding the default config
- redeem the ticket the row points at, not `messages[0]`
- honour `--autoRedeem` (it was accepted but never read)
- log the error before marking a page `Bot Failed`

Tests added for hash extraction and the redeem, failure, and disabled paths.