### PR TITLE
fix(retryable-monitor): keep Notion status in sync with the chain

### DIFF
--- a/packages/retryable-monitor/__test__/alertUntriagedRetryables.test.ts
+++ b/packages/retryable-monitor/__test__/alertUntriagedRetryables.test.ts
@@ -179,6 +179,23 @@ describe('alertUntriagedNotionRetryables', () => {
     expect(pagesUpdate).not.toHaveBeenCalled()
   })
 
+  test('does not redeem when the live status could not be read', async () => {
+    vi.mocked(getLiveRetryableStatus).mockRejectedValue(new Error('rpc down'))
+
+    await alertUntriagedNotionRetryables(CHAINS, true)
+
+    expect(redeemRetryable).not.toHaveBeenCalled()
+    expect(pagesUpdate).not.toHaveBeenCalled()
+  })
+
+  test('does not redeem when the ticket cannot be located', async () => {
+    vi.mocked(getLiveRetryableStatus).mockResolvedValue(null)
+
+    await alertUntriagedNotionRetryables(CHAINS, true)
+
+    expect(redeemRetryable).not.toHaveBeenCalled()
+  })
+
   test('does not redeem when auto-redeem is disabled', async () => {
     await alertUntriagedNotionRetryables(CHAINS, false)
 

--- a/packages/retryable-monitor/__test__/alertUntriagedRetryables.test.ts
+++ b/packages/retryable-monitor/__test__/alertUntriagedRetryables.test.ts
@@ -167,6 +167,32 @@ describe('alertUntriagedNotionRetryables', () => {
     )
   })
 
+  test('queries executed rows that are still marked for redemption', async () => {
+    await alertUntriagedNotionRetryables(CHAINS, true)
+
+    expect(databasesQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filter: {
+          or: [
+            {
+              and: [
+                { property: 'Decision', select: { equals: 'Triage' } },
+                {
+                  property: 'Status',
+                  select: { does_not_equal: 'Executed' },
+                },
+              ],
+            },
+            {
+              property: 'Decision',
+              select: { equals: 'Should Redeem' },
+            },
+          ],
+        },
+      })
+    )
+  })
+
   test('marks the page as failed when the redeem throws', async () => {
     vi.mocked(redeemRetryable).mockRejectedValueOnce(new Error('boom'))
 

--- a/packages/retryable-monitor/__test__/alertUntriagedRetryables.test.ts
+++ b/packages/retryable-monitor/__test__/alertUntriagedRetryables.test.ts
@@ -11,7 +11,12 @@ vi.mock('../handlers/notion/createNotionClient', () => ({
   databaseId: 'test-db',
 }))
 
-vi.mock('../core/redeemRetryable', () => ({ redeemRetryable: vi.fn() }))
+vi.mock('../core/redeemRetryable', () => ({
+  redeemRetryable: vi.fn(),
+  getLiveRetryableStatus: vi.fn(),
+  NOTION_EXECUTED_STATUS: 'Executed',
+  REDEEMABLE_STATUS: 'FUNDS_DEPOSITED_ON_CHILD',
+}))
 
 vi.mock('../handlers/slack/postSlackMessage', () => ({
   postSlackMessage: vi.fn(),
@@ -21,7 +26,10 @@ import {
   alertUntriagedNotionRetryables,
   extractTxHash,
 } from '../handlers/notion/alertUntriagedRetraybles'
-import { redeemRetryable } from '../core/redeemRetryable'
+import {
+  redeemRetryable,
+  getLiveRetryableStatus,
+} from '../core/redeemRetryable'
 
 const PARENT_TX_HASH =
   '0xe60d848b8fae81b103135825c30c2ca169170100cad7fbdf3e73d062e3fc90d6'
@@ -37,7 +45,7 @@ const buildPage = (
   id: 'page-1',
   properties: {
     ChainID: { number: 42161 },
-    Status: { select: { name: 'Pending' } },
+    Status: { select: { name: 'FUNDS_DEPOSITED_ON_CHILD' } },
     Decision: { select: { name: 'Should Redeem' } },
     ParentTx: {
       rich_text: [
@@ -76,6 +84,9 @@ describe('alertUntriagedNotionRetryables', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     databasesQuery.mockResolvedValue({ results: [buildPage(48)] })
+    vi.mocked(getLiveRetryableStatus).mockResolvedValue(
+      'FUNDS_DEPOSITED_ON_CHILD'
+    )
   })
 
   test('redeems with the raw hash, not the explorer URL', async () => {
@@ -83,13 +94,55 @@ describe('alertUntriagedNotionRetryables', () => {
 
     expect(redeemRetryable).toHaveBeenCalledWith(
       PARENT_TX_HASH,
-      expect.objectContaining({ retryableCreationId: CHILD_TX_HASH })
+      expect.objectContaining({
+        retryableCreationId: CHILD_TX_HASH,
+        chainId: 42161,
+      })
     )
+  })
+
+  test('marks the page executed as well as redeemed on success', async () => {
+    await alertUntriagedNotionRetryables(CHAINS, true)
+
     expect(pagesUpdate).toHaveBeenCalledWith(
       expect.objectContaining({
         properties: {
+          Status: { select: { name: 'Executed' } },
           'Bot Redemption Status': { select: { name: 'Bot Success' } },
         },
+      })
+    )
+  })
+
+  test('writes back the live status when Notion is stale', async () => {
+    vi.mocked(getLiveRetryableStatus).mockResolvedValue('CREATION_FAILED')
+
+    await alertUntriagedNotionRetryables(CHAINS, true)
+
+    expect(pagesUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        properties: { Status: { select: { name: 'CREATION_FAILED' } } },
+      })
+    )
+  })
+
+  test('does not redeem a ticket that is not sitting on the child chain', async () => {
+    vi.mocked(getLiveRetryableStatus).mockResolvedValue('CREATION_FAILED')
+
+    await alertUntriagedNotionRetryables(CHAINS, true)
+
+    expect(redeemRetryable).not.toHaveBeenCalled()
+  })
+
+  test('records a ticket redeemed elsewhere as executed without redeeming', async () => {
+    vi.mocked(getLiveRetryableStatus).mockResolvedValue('Executed')
+
+    await alertUntriagedNotionRetryables(CHAINS, true)
+
+    expect(redeemRetryable).not.toHaveBeenCalled()
+    expect(pagesUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        properties: { Status: { select: { name: 'Executed' } } },
       })
     )
   })

--- a/packages/retryable-monitor/__test__/alertUntriagedRetryables.test.ts
+++ b/packages/retryable-monitor/__test__/alertUntriagedRetryables.test.ts
@@ -15,6 +15,7 @@ vi.mock('../core/redeemRetryable', () => ({
   redeemRetryable: vi.fn(),
   getLiveRetryableStatus: vi.fn(),
   NOTION_EXECUTED_STATUS: 'Executed',
+  NOTION_REDEEMED_DECISION: 'Redeemed',
   REDEEMABLE_STATUS: 'FUNDS_DEPOSITED_ON_CHILD',
 }))
 
@@ -108,6 +109,7 @@ describe('alertUntriagedNotionRetryables', () => {
       expect.objectContaining({
         properties: {
           Status: { select: { name: 'Executed' } },
+          Decision: { select: { name: 'Redeemed' } },
           'Bot Redemption Status': { select: { name: 'Bot Success' } },
         },
       })
@@ -142,7 +144,25 @@ describe('alertUntriagedNotionRetryables', () => {
     expect(redeemRetryable).not.toHaveBeenCalled()
     expect(pagesUpdate).toHaveBeenCalledWith(
       expect.objectContaining({
-        properties: { Status: { select: { name: 'Executed' } } },
+        properties: {
+          Status: { select: { name: 'Executed' } },
+          Decision: { select: { name: 'Redeemed' } },
+        },
+      })
+    )
+  })
+
+  test('retires the decision of a row already marked executed', async () => {
+    const page = buildPage(48)
+    page.properties.Status = { select: { name: 'Executed' } }
+    databasesQuery.mockResolvedValue({ results: [page] })
+    vi.mocked(getLiveRetryableStatus).mockResolvedValue('Executed')
+
+    await alertUntriagedNotionRetryables(CHAINS, true)
+
+    expect(pagesUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        properties: { Decision: { select: { name: 'Redeemed' } } },
       })
     )
   })

--- a/packages/retryable-monitor/__test__/findSuccessfulRedeem.test.ts
+++ b/packages/retryable-monitor/__test__/findSuccessfulRedeem.test.ts
@@ -65,15 +65,26 @@ describe('findSuccessfulRedeem', () => {
     )
   })
 
-  test('walks the range in windows instead of one unbounded query', async () => {
-    provider.getBlockNumber.mockResolvedValue(5_000)
-    provider.getBlock.mockResolvedValue({ timestamp: 0 })
+  test('splits the range into bounded chunks', async () => {
+    provider.getBlockNumber.mockResolvedValue(10_000)
 
     await findSuccessfulRedeem(TICKET_ID, 0, provider)
 
     expect(provider.getLogs.mock.calls.length).toBeGreaterThan(1)
-    expect(provider.getLogs).toHaveBeenCalledWith(
-      expect.objectContaining({ fromBlock: 0, toBlock: 1_000 })
+    for (const [{ fromBlock, toBlock }] of provider.getLogs.mock.calls) {
+      expect(toBlock - fromBlock).toBeLessThan(2_000)
+    }
+  })
+
+  test('stops scanning once the redeem is found', async () => {
+    provider.getBlockNumber.mockResolvedValue(10_000)
+    provider.getLogs.mockResolvedValueOnce([redeemScheduledLog()])
+    provider.getTransactionReceipt.mockResolvedValue({ status: 1 })
+
+    await expect(findSuccessfulRedeem(TICKET_ID, 0, provider)).resolves.toBe(
+      RETRY_TX_HASH
     )
+
+    expect(provider.getLogs).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/retryable-monitor/__test__/findSuccessfulRedeem.test.ts
+++ b/packages/retryable-monitor/__test__/findSuccessfulRedeem.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { ArbRetryableTx__factory } from '@arbitrum/sdk/dist/lib/abi/factories/ArbRetryableTx__factory'
+import { findSuccessfulRedeem } from '../core/reportGenerator'
+
+const iface = ArbRetryableTx__factory.createInterface()
+
+const TICKET_ID = `0x${'11'.repeat(32)}`
+const RETRY_TX_HASH = `0x${'22'.repeat(32)}`
+
+const redeemScheduledLog = () => {
+  const { data, topics } = iface.encodeEventLog(
+    iface.getEvent('RedeemScheduled'),
+    [TICKET_ID, RETRY_TX_HASH, 1, 0, `0x${'00'.repeat(20)}`, 0, 0]
+  )
+  return { data, topics }
+}
+
+const buildProvider = () =>
+  ({
+    _isProvider: true,
+    getBlockNumber: vi.fn().mockResolvedValue(1_000),
+    getLogs: vi.fn().mockResolvedValue([]),
+    getTransactionReceipt: vi.fn().mockResolvedValue(null),
+    getBlock: vi.fn().mockResolvedValue({ timestamp: 0 }),
+  } as any)
+
+describe('findSuccessfulRedeem', () => {
+  let provider: any
+
+  beforeEach(() => {
+    provider = buildProvider()
+  })
+
+  test('returns the redeem tx hash when the ticket was redeemed', async () => {
+    provider.getLogs.mockResolvedValue([redeemScheduledLog()])
+    provider.getTransactionReceipt.mockResolvedValue({ status: 1 })
+
+    await expect(findSuccessfulRedeem(TICKET_ID, 0, provider)).resolves.toBe(
+      RETRY_TX_HASH
+    )
+  })
+
+  test('ignores a redeem attempt that reverted', async () => {
+    provider.getLogs.mockResolvedValue([redeemScheduledLog()])
+    provider.getTransactionReceipt.mockResolvedValue({ status: 0 })
+
+    await expect(
+      findSuccessfulRedeem(TICKET_ID, 0, provider)
+    ).resolves.toBeUndefined()
+  })
+
+  test('returns undefined when the ticket was never redeemed', async () => {
+    await expect(
+      findSuccessfulRedeem(TICKET_ID, 0, provider)
+    ).resolves.toBeUndefined()
+  })
+
+  test('filters logs by the ticket id', async () => {
+    await findSuccessfulRedeem(TICKET_ID, 0, provider)
+
+    expect(provider.getLogs).toHaveBeenCalledWith(
+      expect.objectContaining({
+        topics: expect.arrayContaining([TICKET_ID]),
+      })
+    )
+  })
+
+  test('walks the range in windows instead of one unbounded query', async () => {
+    provider.getBlockNumber.mockResolvedValue(5_000)
+    provider.getBlock.mockResolvedValue({ timestamp: 0 })
+
+    await findSuccessfulRedeem(TICKET_ID, 0, provider)
+
+    expect(provider.getLogs.mock.calls.length).toBeGreaterThan(1)
+    expect(provider.getLogs).toHaveBeenCalledWith(
+      expect.objectContaining({ fromBlock: 0, toBlock: 1_000 })
+    )
+  })
+})

--- a/packages/retryable-monitor/__test__/redeemRetryable.test.ts
+++ b/packages/retryable-monitor/__test__/redeemRetryable.test.ts
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+const TICKET_ID = `0x${'11'.repeat(32)}`
+const PARENT_TX = `0x${'aa'.repeat(32)}`
+const REDEEM_TX = `0x${'bb'.repeat(32)}`
+const RETRY_TX = `0x${'cc'.repeat(32)}`
+
+const CHAIN = {
+  chainId: 4663,
+  name: 'Robinhood Chain',
+  parentRpcUrl: 'https://parent.example',
+  orbitRpcUrl: 'https://child.example',
+}
+
+const precompileRedeem = vi.fn()
+const waitForRedeem = vi.fn()
+const getParentToChildMessages = vi.fn()
+
+vi.mock('utils', async importOriginal => ({
+  ...(await importOriginal<typeof import('utils')>()),
+  getConfig: vi.fn(() => ({ childChains: [CHAIN] })),
+}))
+
+vi.mock('ethers', async importOriginal => {
+  const actual = await importOriginal<typeof import('ethers')>()
+  return {
+    ...actual,
+    providers: {
+      ...actual.providers,
+      JsonRpcProvider: vi.fn(() => ({
+        getTransactionReceipt: vi.fn().mockResolvedValue({ logs: [] }),
+      })),
+    },
+    Wallet: vi.fn(() => ({})),
+  }
+})
+
+vi.mock('@arbitrum/sdk', () => ({
+  ParentTransactionReceipt: vi.fn(() => ({ getParentToChildMessages })),
+  ParentToChildMessageStatus: {
+    1: 'NOT_YET_CREATED',
+    2: 'CREATION_FAILED',
+    3: 'FUNDS_DEPOSITED_ON_CHILD',
+    4: 'REDEEMED',
+    5: 'EXPIRED',
+    NOT_YET_CREATED: 1,
+    CREATION_FAILED: 2,
+    FUNDS_DEPOSITED_ON_CHILD: 3,
+    REDEEMED: 4,
+    EXPIRED: 5,
+  },
+  ChildTransactionReceipt: {
+    monkeyPatchWait: (tx: unknown) => tx,
+    toRedeemTransaction: () => ({ waitForRedeem }),
+  },
+}))
+
+vi.mock(
+  '@arbitrum/sdk/dist/lib/abi/factories/ArbRetryableTx__factory',
+  () => ({
+    ArbRetryableTx__factory: { connect: () => ({ redeem: precompileRedeem }) },
+  })
+)
+
+vi.mock('../core/reportGenerator', () => ({
+  getLiveTicketTimeout: vi.fn(),
+  hasTicketCreatedEvent: vi.fn(),
+  findSuccessfulRedeem: vi.fn(),
+}))
+
+import { redeemRetryable } from '../core/redeemRetryable'
+import { getLiveTicketTimeout } from '../core/reportGenerator'
+
+describe('redeemRetryable', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    process.env.RETRYABLE_MONITORING_PRIVATE_KEY = `0x${'01'.repeat(32)}`
+
+    getParentToChildMessages.mockResolvedValue([
+      { retryableCreationId: TICKET_ID },
+    ])
+    vi.mocked(getLiveTicketTimeout).mockResolvedValue({ toString: () => '1' } as any)
+    precompileRedeem.mockResolvedValue({ hash: REDEEM_TX })
+    waitForRedeem.mockResolvedValue({ status: 1, transactionHash: RETRY_TX })
+  })
+
+  test('redeems via the precompile rather than the SDK status guard', async () => {
+    await expect(
+      redeemRetryable(PARENT_TX, { retryableCreationId: TICKET_ID })
+    ).resolves.toBe(RETRY_TX)
+
+    expect(precompileRedeem).toHaveBeenCalledWith(TICKET_ID)
+  })
+
+  test('does not redeem a ticket that no longer exists', async () => {
+    vi.mocked(getLiveTicketTimeout).mockResolvedValue(undefined)
+
+    await expect(
+      redeemRetryable(PARENT_TX, { retryableCreationId: TICKET_ID })
+    ).rejects.toThrow(/not found\/redeemable/)
+
+    expect(precompileRedeem).not.toHaveBeenCalled()
+  })
+
+  test('throws when the scheduled retry execution reverted', async () => {
+    waitForRedeem.mockResolvedValue({ status: 0, transactionHash: RETRY_TX })
+
+    await expect(
+      redeemRetryable(PARENT_TX, { retryableCreationId: TICKET_ID })
+    ).rejects.toThrow(/did not succeed/)
+  })
+
+  test('throws when the retry receipt is missing', async () => {
+    waitForRedeem.mockResolvedValue(null)
+
+    await expect(
+      redeemRetryable(PARENT_TX, { retryableCreationId: TICKET_ID })
+    ).rejects.toThrow(/did not succeed/)
+  })
+
+  test('never redeems a sibling ticket from the same parent tx', async () => {
+    getParentToChildMessages.mockResolvedValue([
+      { retryableCreationId: `0x${'99'.repeat(32)}` },
+    ])
+
+    await expect(
+      redeemRetryable(PARENT_TX, { retryableCreationId: TICKET_ID })
+    ).rejects.toThrow(/not found\/redeemable/)
+
+    expect(precompileRedeem).not.toHaveBeenCalled()
+  })
+})

--- a/packages/retryable-monitor/core/redeemRetryable.ts
+++ b/packages/retryable-monitor/core/redeemRetryable.ts
@@ -12,6 +12,7 @@ import {
   getLiveTicketTimeout,
   hasTicketCreatedEvent,
   findSuccessfulRedeem,
+  isPastTicketLifetime,
 } from './reportGenerator'
 
 dotenv.config()
@@ -141,6 +142,15 @@ export const getLiveRetryableStatus = async (
       childChainProvider
     )
     if (redeemTxHash) return NOTION_EXECUTED_STATUS
+
+    // resolve expiry the same way the checker does, or the two would write
+    // conflicting statuses for the same ticket
+    const { timestamp } = await childChainProvider.getBlock(
+      creationReceipt.blockNumber
+    )
+    if (isPastTicketLifetime(timestamp)) {
+      return ParentToChildMessageStatus[ParentToChildMessageStatus.EXPIRED]
+    }
   }
 
   return ParentToChildMessageStatus[status]

--- a/packages/retryable-monitor/core/redeemRetryable.ts
+++ b/packages/retryable-monitor/core/redeemRetryable.ts
@@ -2,10 +2,17 @@ import { providers, Wallet } from 'ethers'
 import {
   ParentTransactionReceipt,
   ParentToChildMessageStatus,
+  ChildTransactionReceipt,
 } from '@arbitrum/sdk'
+import { ARB_RETRYABLE_TX_ADDRESS } from '@arbitrum/sdk/dist/lib/dataEntities/constants'
+import { ArbRetryableTx__factory } from '@arbitrum/sdk/dist/lib/abi/factories/ArbRetryableTx__factory'
 import { getConfig, DEFAULT_CONFIG_PATH, ChildNetwork } from 'utils'
 import dotenv from 'dotenv'
-import { getLiveTicketTimeout } from './reportGenerator'
+import {
+  getLiveTicketTimeout,
+  hasTicketCreatedEvent,
+  findSuccessfulRedeem,
+} from './reportGenerator'
 
 dotenv.config()
 
@@ -79,7 +86,7 @@ const locateMessage = async (
         : messages[0]
       if (!message) continue
 
-      return { message, childChain, childChainProvider, errors }
+      return { message, childChain, childChainProvider, wallet, errors }
     } catch (err) {
       console.error(
         `Error while processing parentTx ${parentTxHash} on chain ${childChain.chainId}:`,
@@ -93,6 +100,7 @@ const locateMessage = async (
     message: null,
     childChain: null,
     childChainProvider: null,
+    wallet: null,
     errors,
   }
 }
@@ -118,14 +126,30 @@ export const getLiveRetryableStatus = async (
     return NOTION_EXECUTED_STATUS
   }
 
-  // a submit-retryable tx can be marked reverted even though the ticket was
-  // created, which makes the SDK report live tickets as CREATION_FAILED
+  // A submit-retryable tx can be marked reverted even though the ticket was
+  // created. The SDK reports those as CREATION_FAILED and returns before it
+  // looks for a redemption, so both "still live" and "already redeemed" have
+  // to be established here instead.
   if (status === ParentToChildMessageStatus.CREATION_FAILED) {
+    const creationReceipt = await message.getRetryableCreationReceipt()
+    if (!creationReceipt || !hasTicketCreatedEvent(creationReceipt)) {
+      return ParentToChildMessageStatus[status]
+    }
+
     const onChainTimeout = await getLiveTicketTimeout(
       message.retryableCreationId,
       childChainProvider
     )
     if (onChainTimeout !== undefined) return REDEEMABLE_STATUS
+
+    // the ticket was created but is gone, so it was redeemed, cancelled or
+    // expired; only a successful redeem tx proves the first
+    const redeemTxHash = await findSuccessfulRedeem(
+      message.retryableCreationId,
+      creationReceipt.blockNumber,
+      childChainProvider
+    )
+    if (redeemTxHash) return NOTION_EXECUTED_STATUS
   }
 
   return ParentToChildMessageStatus[status]
@@ -135,26 +159,40 @@ export const redeemRetryable = async (
   parentTxHash: string,
   options: LocateOptions = {}
 ): Promise<string> => {
-  const { message, childChain, errors } = await locateMessage(
-    parentTxHash,
-    options
-  )
+  const { message, childChain, childChainProvider, wallet, errors } =
+    await locateMessage(parentTxHash, options)
 
-  if (message && childChain) {
-    const already = await message.getSuccessfulRedeem().catch(() => null)
-    if (already && already.status === ParentToChildMessageStatus.REDEEMED) {
-      const existingHash =
-        (already as any)?.childTxReceipt?.transactionHash ??
-        (already as any)?.txHash
-      if (existingHash) return existingHash
-    }
-
+  if (message && childChain && childChainProvider && wallet) {
     try {
-      const tx = await message.redeem()
-      console.log(
-        `Sent redeem tx on childChain ${childChain.chainId}: ${tx.hash}`
+      // The SDK's redeem() re-derives status() and rejects any ticket whose
+      // creation receipt is marked reverted, even when the ticket is live and
+      // redeemable. getTimeout() reverting with NoTicketWithID is the only
+      // thing that proves a ticket does not exist, so it stands in for the
+      // SDK's guard and we call the precompile ourselves.
+      const onChainTimeout = await getLiveTicketTimeout(
+        message.retryableCreationId,
+        childChainProvider
       )
-      const redeemReceipt = await tx.waitForRedeem()
+
+      if (onChainTimeout === undefined) {
+        throw new Error(
+          `Ticket ${message.retryableCreationId} no longer exists on chain ${childChain.chainId}`
+        )
+      }
+
+      const arbRetryableTx = ArbRetryableTx__factory.connect(
+        ARB_RETRYABLE_TX_ADDRESS,
+        wallet
+      )
+      const redeemTx = await arbRetryableTx.redeem(message.retryableCreationId)
+      console.log(
+        `Sent redeem tx on childChain ${childChain.chainId}: ${redeemTx.hash}`
+      )
+
+      const redeemReceipt = await ChildTransactionReceipt.toRedeemTransaction(
+        ChildTransactionReceipt.monkeyPatchWait(redeemTx),
+        childChainProvider
+      ).waitForRedeem()
       console.log(
         `Redeem successful on childChain ${childChain.chainId}: ${redeemReceipt.transactionHash}`
       )

--- a/packages/retryable-monitor/core/redeemRetryable.ts
+++ b/packages/retryable-monitor/core/redeemRetryable.ts
@@ -18,6 +18,7 @@ import {
 dotenv.config()
 
 export const NOTION_EXECUTED_STATUS = 'Executed'
+export const NOTION_REDEEMED_DECISION = 'Redeemed'
 export const REDEEMABLE_STATUS =
   ParentToChildMessageStatus[
     ParentToChildMessageStatus.FUNDS_DEPOSITED_ON_CHILD

--- a/packages/retryable-monitor/core/redeemRetryable.ts
+++ b/packages/retryable-monitor/core/redeemRetryable.ts
@@ -3,16 +3,32 @@ import {
   ParentTransactionReceipt,
   ParentToChildMessageStatus,
 } from '@arbitrum/sdk'
-import { getConfig, DEFAULT_CONFIG_PATH } from 'utils'
+import { getConfig, DEFAULT_CONFIG_PATH, ChildNetwork } from 'utils'
 import dotenv from 'dotenv'
+import { getLiveTicketTimeout } from './reportGenerator'
 
 dotenv.config()
 
-export const redeemRetryable = async (
+export const NOTION_EXECUTED_STATUS = 'Executed'
+export const REDEEMABLE_STATUS =
+  ParentToChildMessageStatus[
+    ParentToChildMessageStatus.FUNDS_DEPOSITED_ON_CHILD
+  ]
+
+type LocateOptions = {
+  configPath?: string
+  retryableCreationId?: string
+  chainId?: number
+}
+
+const locateMessage = async (
   parentTxHash: string,
-  options: { configPath?: string; retryableCreationId?: string } = {}
-): Promise<string> => {
-  const { configPath = DEFAULT_CONFIG_PATH, retryableCreationId } = options
+  {
+    configPath = DEFAULT_CONFIG_PATH,
+    retryableCreationId,
+    chainId,
+  }: LocateOptions
+) => {
   const config = getConfig({ configPath })
 
   const pk = process.env.RETRYABLE_MONITORING_PRIVATE_KEY
@@ -22,11 +38,16 @@ export const redeemRetryable = async (
     )
   }
 
-  let lastError: unknown
+  // the caller usually knows which chain the ticket belongs to; probing every
+  // configured chain is only a fallback
+  const candidates: ChildNetwork[] = chainId
+    ? config.childChains.filter((c: ChildNetwork) => c.chainId === chainId)
+    : config.childChains
 
-  for (const childChain of config.childChains) {
+  const errors: unknown[] = []
+
+  for (const childChain of candidates) {
     try {
-      // 1) Check parent chain for the tx
       const parentChainProvider = new providers.JsonRpcProvider(
         childChain.parentRpcUrl
       )
@@ -35,18 +56,19 @@ export const redeemRetryable = async (
       )
       if (!receipt) continue
 
-      // 2) We found the parent receipt -> attempt on its configured child
       const childChainProvider = new providers.JsonRpcProvider(
         childChain.orbitRpcUrl
       )
       const wallet = new Wallet(pk, childChainProvider)
 
       const parentReceipt = new ParentTransactionReceipt(receipt)
+      // the SDK filters these by the child chain's inbox, so a ticket never
+      // matches a sibling chain that shares the same parent
       const messages = await parentReceipt.getParentToChildMessages(wallet)
-      if (!messages || messages.length === 0) continue // no L1->L2 messages associated; try next chain
+      if (!messages || messages.length === 0) continue
 
       // a parent tx can create several tickets; pick the requested one so we
-      // never redeem a sibling ticket, falling back to the first when the
+      // never touch a sibling ticket, falling back to the first when the
       // caller has no specific ticket in mind
       const message = retryableCreationId
         ? messages.find(
@@ -57,47 +79,99 @@ export const redeemRetryable = async (
         : messages[0]
       if (!message) continue
 
-      // 3) If already redeemed, return its tx hash instead of throwing
-      const already = await message.getSuccessfulRedeem().catch(() => null)
-      if (already && already.status === ParentToChildMessageStatus.REDEEMED) {
-        const existingHash =
-          (already as any)?.childTxReceipt?.transactionHash ??
-          (already as any)?.txHash
-        if (existingHash) return existingHash
-      }
-
-      // 4) Redeem with error logging
-      try {
-        const tx = await message.redeem()
-        console.log(
-          `Sent redeem tx on childChain ${childChain.chainId}: ${tx.hash}`
-        )
-        const redeemReceipt = await tx.waitForRedeem()
-        console.log(
-          `Redeem successful on childChain ${childChain.chainId}: ${redeemReceipt.transactionHash}`
-        )
-        return redeemReceipt.transactionHash
-      } catch (redeemErr) {
-        console.error(
-          `Redeem failed on childChain ${childChain.chainId}. ` +
-            `Check tx hash if available: ${
-              (redeemErr as any)?.transactionHash || 'N/A'
-            }`,
-          redeemErr
-        )
-        lastError = redeemErr
-        continue
-      }
+      return { message, childChain, childChainProvider, errors }
     } catch (err) {
       console.error(
         `Error while processing parentTx ${parentTxHash} on chain ${childChain.chainId}:`,
         err
       )
-      lastError = err
-      continue
+      errors.push(err)
     }
   }
 
+  return {
+    message: null,
+    childChain: null,
+    childChainProvider: null,
+    errors,
+  }
+}
+
+/**
+ * Reads the ticket's current status from the chain, so callers can reflect
+ * reality regardless of who redeemed it. Returns null when the ticket cannot
+ * be located on any configured chain.
+ */
+export const getLiveRetryableStatus = async (
+  parentTxHash: string,
+  options: LocateOptions = {}
+): Promise<string | null> => {
+  const { message, childChainProvider } = await locateMessage(
+    parentTxHash,
+    options
+  )
+  if (!message || !childChainProvider) return null
+
+  const status = await message.status()
+
+  if (status === ParentToChildMessageStatus.REDEEMED) {
+    return NOTION_EXECUTED_STATUS
+  }
+
+  // a submit-retryable tx can be marked reverted even though the ticket was
+  // created, which makes the SDK report live tickets as CREATION_FAILED
+  if (status === ParentToChildMessageStatus.CREATION_FAILED) {
+    const onChainTimeout = await getLiveTicketTimeout(
+      message.retryableCreationId,
+      childChainProvider
+    )
+    if (onChainTimeout !== undefined) return REDEEMABLE_STATUS
+  }
+
+  return ParentToChildMessageStatus[status]
+}
+
+export const redeemRetryable = async (
+  parentTxHash: string,
+  options: LocateOptions = {}
+): Promise<string> => {
+  const { message, childChain, errors } = await locateMessage(
+    parentTxHash,
+    options
+  )
+
+  if (message && childChain) {
+    const already = await message.getSuccessfulRedeem().catch(() => null)
+    if (already && already.status === ParentToChildMessageStatus.REDEEMED) {
+      const existingHash =
+        (already as any)?.childTxReceipt?.transactionHash ??
+        (already as any)?.txHash
+      if (existingHash) return existingHash
+    }
+
+    try {
+      const tx = await message.redeem()
+      console.log(
+        `Sent redeem tx on childChain ${childChain.chainId}: ${tx.hash}`
+      )
+      const redeemReceipt = await tx.waitForRedeem()
+      console.log(
+        `Redeem successful on childChain ${childChain.chainId}: ${redeemReceipt.transactionHash}`
+      )
+      return redeemReceipt.transactionHash
+    } catch (redeemErr) {
+      console.error(
+        `Redeem failed on childChain ${childChain.chainId}. ` +
+          `Check tx hash if available: ${
+            (redeemErr as any)?.transactionHash || 'N/A'
+          }`,
+        redeemErr
+      )
+      errors.push(redeemErr)
+    }
+  }
+
+  const lastError = errors[errors.length - 1]
   const suffix =
     lastError instanceof Error ? ` Last error: ${lastError.message}` : ''
   throw new Error(

--- a/packages/retryable-monitor/core/redeemRetryable.ts
+++ b/packages/retryable-monitor/core/redeemRetryable.ts
@@ -45,8 +45,6 @@ const locateMessage = async (
     )
   }
 
-  // the caller usually knows which chain the ticket belongs to; probing every
-  // configured chain is only a fallback
   const candidates: ChildNetwork[] = chainId
     ? config.childChains.filter((c: ChildNetwork) => c.chainId === chainId)
     : config.childChains
@@ -70,13 +68,11 @@ const locateMessage = async (
 
       const parentReceipt = new ParentTransactionReceipt(receipt)
       // the SDK filters these by the child chain's inbox, so a ticket never
-      // matches a sibling chain that shares the same parent
+      // matches a sibling chain sharing the same parent
       const messages = await parentReceipt.getParentToChildMessages(wallet)
       if (!messages || messages.length === 0) continue
 
-      // a parent tx can create several tickets; pick the requested one so we
-      // never touch a sibling ticket, falling back to the first when the
-      // caller has no specific ticket in mind
+      // a parent tx can create several tickets; never touch a sibling
       const message = retryableCreationId
         ? messages.find(
             m =>
@@ -106,9 +102,7 @@ const locateMessage = async (
 }
 
 /**
- * Reads the ticket's current status from the chain, so callers can reflect
- * reality regardless of who redeemed it. Returns null when the ticket cannot
- * be located on any configured chain.
+ * Reads the ticket's status from the chain. Null if it cannot be located.
  */
 export const getLiveRetryableStatus = async (
   parentTxHash: string,
@@ -126,10 +120,8 @@ export const getLiveRetryableStatus = async (
     return NOTION_EXECUTED_STATUS
   }
 
-  // A submit-retryable tx can be marked reverted even though the ticket was
-  // created. The SDK reports those as CREATION_FAILED and returns before it
-  // looks for a redemption, so both "still live" and "already redeemed" have
-  // to be established here instead.
+  // a submit-retryable tx can be marked reverted even though the ticket was
+  // created, and the SDK calls those CREATION_FAILED without looking further
   if (status === ParentToChildMessageStatus.CREATION_FAILED) {
     const creationReceipt = await message.getRetryableCreationReceipt()
     if (!creationReceipt || !hasTicketCreatedEvent(creationReceipt)) {
@@ -142,8 +134,7 @@ export const getLiveRetryableStatus = async (
     )
     if (onChainTimeout !== undefined) return REDEEMABLE_STATUS
 
-    // the ticket was created but is gone, so it was redeemed, cancelled or
-    // expired; only a successful redeem tx proves the first
+    // created but gone: redeemed, cancelled or expired
     const redeemTxHash = await findSuccessfulRedeem(
       message.retryableCreationId,
       creationReceipt.blockNumber,
@@ -164,11 +155,8 @@ export const redeemRetryable = async (
 
   if (message && childChain && childChainProvider && wallet) {
     try {
-      // The SDK's redeem() re-derives status() and rejects any ticket whose
-      // creation receipt is marked reverted, even when the ticket is live and
-      // redeemable. getTimeout() reverting with NoTicketWithID is the only
-      // thing that proves a ticket does not exist, so it stands in for the
-      // SDK's guard and we call the precompile ourselves.
+      // the SDK's redeem() rejects tickets it reports as CREATION_FAILED, so
+      // NoTicketWithID stands in for its guard and we call the precompile
       const onChainTimeout = await getLiveTicketTimeout(
         message.retryableCreationId,
         childChainProvider
@@ -193,6 +181,17 @@ export const redeemRetryable = async (
         ChildTransactionReceipt.monkeyPatchWait(redeemTx),
         childChainProvider
       ).waitForRedeem()
+
+      // waitForRedeem does not inspect the receipt, and a reverted retry
+      // leaves the ticket redeemable
+      if (redeemReceipt?.status !== 1) {
+        throw new Error(
+          `Retry execution ${
+            redeemReceipt?.transactionHash ?? '(no receipt)'
+          } for ticket ${message.retryableCreationId} did not succeed`
+        )
+      }
+
       console.log(
         `Redeem successful on childChain ${childChain.chainId}: ${redeemReceipt.transactionHash}`
       )

--- a/packages/retryable-monitor/core/reportGenerator.ts
+++ b/packages/retryable-monitor/core/reportGenerator.ts
@@ -27,7 +27,7 @@ export const TICKET_CREATED_TOPIC =
 // a submit-retryable tx emits TicketCreated even when its receipt is marked
 // as reverted (e.g. when the requested auto-redeem could not be paid for), so
 // the event is what proves a ticket was actually created
-const hasTicketCreatedEvent = (receipt: TransactionReceipt): boolean =>
+export const hasTicketCreatedEvent = (receipt: TransactionReceipt): boolean =>
   (receipt.logs ?? []).some(
     log =>
       log.address.toLowerCase() === ARB_RETRYABLE_TX_ADDRESS.toLowerCase() &&
@@ -79,6 +79,64 @@ export const getLiveTicketTimeout = async (
     if (isNoTicketWithIdError(error)) return undefined
     throw error
   }
+}
+
+/**
+ * Returns the hash of the child chain tx that successfully redeemed the
+ * ticket, or undefined if it was never redeemed.
+ *
+ * Needed because the SDK reports any ticket whose creation receipt is marked
+ * reverted as CREATION_FAILED and returns before it looks for a redemption,
+ * so a redeemed ticket of that kind never reports as REDEEMED.
+ */
+export const findSuccessfulRedeem = async (
+  ticketId: string,
+  creationBlockNumber: number,
+  childChainProvider: providers.Provider
+): Promise<string | undefined> => {
+  const arbRetryableTx = ArbRetryableTx__factory.connect(
+    ARB_RETRYABLE_TX_ADDRESS,
+    childChainProvider
+  )
+  const filter = arbRetryableTx.filters.RedeemScheduled(ticketId)
+
+  const latestBlock = await childChainProvider.getBlockNumber()
+  let fromBlock = creationBlockNumber
+  let increment = 1000
+
+  while (fromBlock <= latestBlock) {
+    const toBlock = Math.min(fromBlock + increment, latestBlock)
+
+    const logs = await withRetry(
+      () => childChainProvider.getLogs({ ...filter, fromBlock, toBlock }),
+      { label: 'ArbRetryableTx.RedeemScheduled' }
+    )
+
+    for (const log of logs) {
+      const { retryTxHash } = arbRetryableTx.interface.parseLog(log).args
+      const receipt = await childChainProvider.getTransactionReceipt(
+        retryTxHash
+      )
+      if (receipt?.status === 1) return retryTxHash
+    }
+
+    if (toBlock === latestBlock) break
+
+    // size the next window to roughly a day, so scanning a ticket's whole
+    // lifetime costs a handful of queries rather than thousands on a chain
+    // with sub-second blocks
+    const [fromBlockData, toBlockData] = await Promise.all([
+      childChainProvider.getBlock(fromBlock),
+      childChainProvider.getBlock(toBlock),
+    ])
+    const processedSeconds = toBlockData.timestamp - fromBlockData.timestamp
+    if (processedSeconds > 0) {
+      increment = Math.ceil((increment * 86400) / processedSeconds)
+    }
+    fromBlock = toBlock + 1
+  }
+
+  return undefined
 }
 
 export const getParentChainRetryableReport = (

--- a/packages/retryable-monitor/core/reportGenerator.ts
+++ b/packages/retryable-monitor/core/reportGenerator.ts
@@ -14,11 +14,14 @@ import {
   SEVEN_DAYS_IN_SECONDS,
 } from '@arbitrum/sdk/dist/lib/dataEntities/constants'
 import { ArbRetryableTx__factory } from '@arbitrum/sdk/dist/lib/abi/factories/ArbRetryableTx__factory'
-import { withRetry } from 'utils'
+import { withRetry, processBlockRangeInChunks } from 'utils'
 import { ChildChainTicketReport, ParentChainTicketReport } from './types'
 
 // selector of ArbRetryableTx's NoTicketWithID() custom error
 const NO_TICKET_WITH_ID_SELECTOR = '0x80698456'
+
+// same ceiling the checker scans with, so an RPC that accepts one accepts both
+const REDEEM_SCAN_CHUNK_SIZE = 2000
 
 // keccak256 of ArbRetryableTx's TicketCreated(bytes32) event signature
 export const TICKET_CREATED_TOPIC =
@@ -97,43 +100,36 @@ export const findSuccessfulRedeem = async (
     childChainProvider
   )
   const filter = arbRetryableTx.filters.RedeemScheduled(ticketId)
-
   const latestBlock = await childChainProvider.getBlockNumber()
-  let fromBlock = creationBlockNumber
-  let increment = 1000
 
-  while (fromBlock <= latestBlock) {
-    const toBlock = Math.min(fromBlock + increment, latestBlock)
-
-    const logs = await withRetry(
-      () => childChainProvider.getLogs({ ...filter, fromBlock, toBlock }),
-      { label: 'ArbRetryableTx.RedeemScheduled' }
-    )
-
-    for (const log of logs) {
-      const { retryTxHash } = arbRetryableTx.interface.parseLog(log).args
-      const receipt = await childChainProvider.getTransactionReceipt(
-        retryTxHash
+  return processBlockRangeInChunks<string | undefined>(
+    creationBlockNumber,
+    latestBlock,
+    REDEEM_SCAN_CHUNK_SIZE,
+    async (fromBlock, toBlock) => {
+      const logs = await withRetry(
+        () => childChainProvider.getLogs({ ...filter, fromBlock, toBlock }),
+        { label: 'ArbRetryableTx.RedeemScheduled' }
       )
-      if (receipt?.status === 1) return retryTxHash
-    }
 
-    if (toBlock === latestBlock) break
+      for (const log of logs) {
+        const { retryTxHash } = arbRetryableTx.interface.parseLog(log).args
+        const receipt = await childChainProvider.getTransactionReceipt(
+          retryTxHash
+        )
+        if (receipt?.status === 1) return retryTxHash
+      }
 
-    // aim for ~a day per window, so a 7-day lifetime costs a few queries
-    const [fromBlockData, toBlockData] = await Promise.all([
-      childChainProvider.getBlock(fromBlock),
-      childChainProvider.getBlock(toBlock),
-    ])
-    const processedSeconds = toBlockData.timestamp - fromBlockData.timestamp
-    if (processedSeconds > 0) {
-      increment = Math.ceil((increment * 86400) / processedSeconds)
-    }
-    fromBlock = toBlock + 1
-  }
-
-  return undefined
+      return undefined
+    },
+    (prev, next) => prev ?? next,
+    undefined,
+    { stopWhen: found => found !== undefined }
+  )
 }
+
+export const isPastTicketLifetime = (createdAtTimestamp: number): boolean =>
+  Date.now() / 1000 >= createdAtTimestamp + SEVEN_DAYS_IN_SECONDS
 
 export const getParentChainRetryableReport = (
   arbParentTxReceipt: ParentTransactionReceipt,
@@ -182,7 +178,7 @@ export const getChildChainRetryableReport = async ({
   if (
     status === ParentToChildMessageStatus.CREATION_FAILED &&
     hasTicketCreatedEvent(childChainTxReceipt) &&
-    Date.now() / 1000 >= Number(timestamp) + SEVEN_DAYS_IN_SECONDS
+    isPastTicketLifetime(Number(timestamp))
   ) {
     status = ParentToChildMessageStatus.EXPIRED
   }

--- a/packages/retryable-monitor/core/reportGenerator.ts
+++ b/packages/retryable-monitor/core/reportGenerator.ts
@@ -82,12 +82,10 @@ export const getLiveTicketTimeout = async (
 }
 
 /**
- * Returns the hash of the child chain tx that successfully redeemed the
- * ticket, or undefined if it was never redeemed.
+ * Hash of the tx that successfully redeemed the ticket, or undefined.
  *
- * Needed because the SDK reports any ticket whose creation receipt is marked
- * reverted as CREATION_FAILED and returns before it looks for a redemption,
- * so a redeemed ticket of that kind never reports as REDEEMED.
+ * Needed because the SDK reports a ticket whose creation receipt is marked
+ * reverted as CREATION_FAILED and returns before it looks for a redemption.
  */
 export const findSuccessfulRedeem = async (
   ticketId: string,
@@ -122,9 +120,7 @@ export const findSuccessfulRedeem = async (
 
     if (toBlock === latestBlock) break
 
-    // size the next window to roughly a day, so scanning a ticket's whole
-    // lifetime costs a handful of queries rather than thousands on a chain
-    // with sub-second blocks
+    // aim for ~a day per window, so a 7-day lifetime costs a few queries
     const [fromBlockData, toBlockData] = await Promise.all([
       childChainProvider.getBlock(fromBlock),
       childChainProvider.getBlock(toBlock),

--- a/packages/retryable-monitor/handlers/notion/alertUntriagedRetraybles.ts
+++ b/packages/retryable-monitor/handlers/notion/alertUntriagedRetraybles.ts
@@ -4,6 +4,7 @@ import {
   redeemRetryable,
   getLiveRetryableStatus,
   NOTION_EXECUTED_STATUS,
+  NOTION_REDEEMED_DECISION,
   REDEEMABLE_STATUS,
 } from '../../core/redeemRetryable'
 import { DEFAULT_CONFIG_PATH, type ChildNetwork } from 'utils'
@@ -138,13 +139,29 @@ export const alertUntriagedNotionRetryables = async (
           )
         }
 
-        if (liveStatus && liveStatus !== status) {
+        // a ticket redeemed by anyone, bot or not, is no longer ours to redeem
+        const liveDecision =
+          liveStatus === NOTION_EXECUTED_STATUS
+            ? NOTION_REDEEMED_DECISION
+            : decision
+
+        const drift = {
+          ...(liveStatus &&
+            liveStatus !== status && {
+              Status: { select: { name: liveStatus } },
+            }),
+          ...(liveDecision !== decision && {
+            Decision: { select: { name: liveDecision } },
+          }),
+        }
+
+        if (Object.keys(drift).length > 0) {
           console.log(
-            `[notion] ${retryableUrl} status ${status} -> ${liveStatus}`
+            `[notion] ${retryableUrl} ${status}/${decision} -> ${liveStatus}/${liveDecision}`
           )
           await notionClient.pages.update({
             page_id: page.id,
-            properties: { Status: { select: { name: liveStatus } } },
+            properties: drift,
           })
         }
 
@@ -165,6 +182,7 @@ export const alertUntriagedNotionRetryables = async (
             page_id: page.id,
             properties: {
               Status: { select: { name: NOTION_EXECUTED_STATUS } },
+              Decision: { select: { name: NOTION_REDEEMED_DECISION } },
               'Bot Redemption Status': {
                 select: { name: 'Bot Success' },
               },

--- a/packages/retryable-monitor/handlers/notion/alertUntriagedRetraybles.ts
+++ b/packages/retryable-monitor/handlers/notion/alertUntriagedRetraybles.ts
@@ -46,17 +46,17 @@ export const alertUntriagedNotionRetryables = async (
     database_id: databaseId,
     page_size: 100,
     filter: {
-      and: [
+      or: [
         {
-          or: [
+          and: [
             { property: 'Decision', select: { equals: 'Triage' } },
-            { property: 'Decision', select: { equals: 'Should Redeem' } },
+            {
+              property: 'Status',
+              select: { does_not_equal: 'Executed' },
+            },
           ],
         },
-        {
-          property: 'Status',
-          select: { does_not_equal: 'Executed' },
-        },
+        { property: 'Decision', select: { equals: 'Should Redeem' } },
       ],
     },
   })

--- a/packages/retryable-monitor/handlers/notion/alertUntriagedRetraybles.ts
+++ b/packages/retryable-monitor/handlers/notion/alertUntriagedRetraybles.ts
@@ -148,10 +148,13 @@ export const alertUntriagedNotionRetryables = async (
           })
         }
 
-        // anything else fails every run until the ticket expires
-        if (liveStatus && liveStatus !== REDEEMABLE_STATUS) {
+        // only redeem on a confirmed redeemable status; a failed lookup is not
+        // evidence the ticket is redeemable
+        if (liveStatus !== REDEEMABLE_STATUS) {
           console.log(
-            `[notion] skipping auto-redeem for ${retryableUrl}, status is ${liveStatus}`
+            `[notion] skipping auto-redeem for ${retryableUrl}, status is ${
+              liveStatus ?? 'unknown'
+            }`
           )
           continue
         }

--- a/packages/retryable-monitor/handlers/notion/alertUntriagedRetraybles.ts
+++ b/packages/retryable-monitor/handlers/notion/alertUntriagedRetraybles.ts
@@ -117,8 +117,7 @@ export const alertUntriagedNotionRetryables = async (
 
         const parentTxHash = extractTxHash(parentTx)
         const retryableCreationId = extractTxHash(retryableUrl)
-        // never fall back to redeeming an arbitrary ticket: without the
-        // row's own ticket id we could redeem a sibling from the same parent tx
+        // without the row's own ticket id we could redeem a sibling
         if (!parentTxHash || !retryableCreationId) {
           console.error(
             `[notion] skipping auto-redeem, could not read tx hashes (parent: "${parentTx}", ticket: "${retryableUrl}")`
@@ -128,8 +127,7 @@ export const alertUntriagedNotionRetryables = async (
 
         const locator = { configPath, retryableCreationId, chainId: chainIdRaw }
 
-        // the ticket may have been redeemed or expired since the row was
-        // written, by us or by anyone else, so trust the chain over Notion
+        // the row may predate a redemption by anyone, so trust the chain
         let liveStatus: string | null = null
         try {
           liveStatus = await getLiveRetryableStatus(parentTxHash, locator)
@@ -150,8 +148,7 @@ export const alertUntriagedNotionRetryables = async (
           })
         }
 
-        // only a ticket whose funds are sitting on the child chain can be
-        // redeemed; anything else would fail every run until it expires
+        // anything else fails every run until the ticket expires
         if (liveStatus && liveStatus !== REDEEMABLE_STATUS) {
           console.log(
             `[notion] skipping auto-redeem for ${retryableUrl}, status is ${liveStatus}`

--- a/packages/retryable-monitor/handlers/notion/alertUntriagedRetraybles.ts
+++ b/packages/retryable-monitor/handlers/notion/alertUntriagedRetraybles.ts
@@ -1,6 +1,11 @@
 import { notionClient, databaseId } from './createNotionClient'
 import { postSlackMessage } from '../slack/postSlackMessage'
-import { redeemRetryable } from '../../core/redeemRetryable'
+import {
+  redeemRetryable,
+  getLiveRetryableStatus,
+  NOTION_EXECUTED_STATUS,
+  REDEEMABLE_STATUS,
+} from '../../core/redeemRetryable'
 import { DEFAULT_CONFIG_PATH, type ChildNetwork } from 'utils'
 
 const formatDate = (iso: string | undefined) => {
@@ -121,14 +126,45 @@ export const alertUntriagedNotionRetryables = async (
           continue
         }
 
+        const locator = { configPath, retryableCreationId, chainId: chainIdRaw }
+
+        // the ticket may have been redeemed or expired since the row was
+        // written, by us or by anyone else, so trust the chain over Notion
+        let liveStatus: string | null = null
         try {
-          await redeemRetryable(parentTxHash, {
-            configPath,
-            retryableCreationId,
+          liveStatus = await getLiveRetryableStatus(parentTxHash, locator)
+        } catch (err) {
+          console.error(
+            `[notion] could not read live status for ${retryableUrl}:`,
+            err
+          )
+        }
+
+        if (liveStatus && liveStatus !== status) {
+          console.log(
+            `[notion] ${retryableUrl} status ${status} -> ${liveStatus}`
+          )
+          await notionClient.pages.update({
+            page_id: page.id,
+            properties: { Status: { select: { name: liveStatus } } },
           })
+        }
+
+        // only a ticket whose funds are sitting on the child chain can be
+        // redeemed; anything else would fail every run until it expires
+        if (liveStatus && liveStatus !== REDEEMABLE_STATUS) {
+          console.log(
+            `[notion] skipping auto-redeem for ${retryableUrl}, status is ${liveStatus}`
+          )
+          continue
+        }
+
+        try {
+          await redeemRetryable(parentTxHash, locator)
           await notionClient.pages.update({
             page_id: page.id,
             properties: {
+              Status: { select: { name: NOTION_EXECUTED_STATUS } },
               'Bot Redemption Status': {
                 select: { name: 'Bot Success' },
               },

--- a/packages/retryable-monitor/index.ts
+++ b/packages/retryable-monitor/index.ts
@@ -201,8 +201,7 @@ const processOrbitChainsConcurrently = async () => {
       options.configPath
     )
 
-    // one sweep covering every chain, never one sweep per chain: concurrent
-    // sweeps read the same rows and would each submit a redemption for them
+    // one sweep for all chains: concurrent sweeps double-redeem the same rows
     if (options.continuous) {
       console.log('Activating continuous sweep of Notion database...')
       setInterval(async () => {


### PR DESCRIPTION
Follow-up to #131. The sweep updated `Bot Redemption Status` but never `Status`, so a row stayed on its old status after the bot redeemed it, and unredeemable tickets were retried every run until they expired.

The sweep now reads the ticket's live status before attempting a redeem, and:

- writes it back to `Status` when it differs from Notion
- skips the redeem and records `Executed` if the ticket was already redeemed, wherever that happened
- skips tickets that are not sitting on the child chain (a `CREATION_FAILED` ticket cannot be redeemed, so retrying it just re-fails)
- sets `Status: Executed` alongside `Bot Redemption Status: Bot Success` on a successful redeem

Status resolution reuses `getLiveTicketTimeout` so it agrees with what the checker writes, instead of trusting the SDK's raw status.

`redeemRetryable` also takes a `chainId` now, so the sweep goes straight to the row's chain rather than probing every configured chain.